### PR TITLE
Remove bad entry for AAT pause shutdown

### DIFF
--- a/issues_list.json
+++ b/issues_list.json
@@ -18,15 +18,6 @@
     },
     {
         "start_date": "04-12-2023",
-        "end_date": "05-12-2023",
-        "request_type": "stop",
-        "environment": "AAT / Staging",
-        "business_area": "cft",
-        "change_jira_id": "https://tools.hmcts.net/jira/browse/RBC-17267",
-        "issue_link": "https://github.com/hmcts/auto-shutdown/issues/247"
-    },
-    {
-        "start_date": "04-12-2023",
         "end_date": "04-12-2023",
         "request_type": "stop",
         "environment": "PTL",


### PR DESCRIPTION
Remove an incorrect entry for AAT shutdown between 04/12 and 05/12 which has been corrected in a later entry.

### Jira link (if applicable)

 https://tools.hmcts.net/jira/browse/RBC-17267
