### PR TITLE
DTSPO-17194 - GitHub -> Slack usernames

### DIFF
--- a/.github/workflows/parsegithubissue.yaml
+++ b/.github/workflows/parsegithubissue.yaml
@@ -29,7 +29,7 @@ jobs:
     #Comment if approver is equal to requester
       - name: Cannot self approve comment
         if: contains(github.event.issue.labels.*.name, 'approved') && github.event.issue.user.login == github.actor || contains(github.event.issue.labels.*.name, 'auto-approved') && github.event.issue.user.login == github.actor
-        uses: peter-evans/create-or-update-comment@v3.1.0
+        uses: peter-evans/create-or-update-comment@v4.0.0
         with:
           issue-number: ${{ github.event.issue.number }}
           body: |
@@ -145,7 +145,7 @@ jobs:
     # Provide any error messages to user as a comment
       - name: Create Issue Comment
         if: env.PROCESS_SUCCESS != 'true'
-        uses: peter-evans/create-or-update-comment@v3.1.0
+        uses: peter-evans/create-or-update-comment@v4.0.0
         with:
           issue-number: ${{ github.event.issue.number }}
           body: |
@@ -159,7 +159,7 @@ jobs:
 
     # Login to Azure CLI (for cost analysis)
       - name: 'Az CLI login'
-        uses: azure/login@v1
+        uses: azure/login@v2
         with:
           client-id: 2b6fa9d7-7dba-4600-a58a-5e25554997aa # DTS AKS Auto-Shutdown
           tenant-id: 531ff96d-0ae9-462a-8d2d-bec7c0b42082 # HMCTS.NET
@@ -184,6 +184,7 @@ jobs:
         run: ./scripts/aks/send-slack-message.sh
         env:
           SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK }}
+          SLACK_TOKEN: ${{ secrets.AUTO_SHUTDOWN_OAUTH_TOKEN }}
           ISSUE_TITLE: ${{ github.event.issue.title }}
           CHANGE_JIRA_ID: ${{ env.CHANGE_JIRA_ID }}
           REQUEST_URL: ${{ env.REQUEST_URL }}
@@ -203,7 +204,7 @@ jobs:
     #Add output of cost calculator as a comment to user
       - name: Add cost details as a comment
         if: env.PROCESS_SUCCESS == 'true' && env.ERROR_IN_COSTS != 'true'
-        uses: peter-evans/create-or-update-comment@v3.1.0
+        uses: peter-evans/create-or-update-comment@v4.0.0
         with:
           issue-number: ${{ github.event.issue.number }}
           body: |
@@ -212,7 +213,7 @@ jobs:
     #If cost calculator fails, provide feedback to user as a comment
       - name: Add cost error details as a comment
         if: env.PROCESS_SUCCESS == 'true' && env.ERROR_IN_COSTS == 'true'
-        uses: peter-evans/create-or-update-comment@v3.1.0
+        uses: peter-evans/create-or-update-comment@v4.0.0
         with:
           issue-number: ${{ github.event.issue.number }}
           body: |
@@ -242,7 +243,7 @@ jobs:
     #Add auto-approval comment if approval_state == auto-approved
       - name: Add auto approval comment
         if: env.APPROVAL_STATE == 'auto-approved'
-        uses: peter-evans/create-or-update-comment@v3.1.0
+        uses: peter-evans/create-or-update-comment@v4.0.0
         with:
           issue-number: ${{ github.event.issue.number }}
           body: |
@@ -260,7 +261,7 @@ jobs:
     #If approval_state == Pending Approval && workflow is running at submission time, not approval time.
       - name: Very High Cost approval comment
         if: env.APPROVAL_STATE == 'Pending Approval' && github.event.issue.user.login == github.actor
-        uses: peter-evans/create-or-update-comment@v3.1.0
+        uses: peter-evans/create-or-update-comment@v4.0.0
         with:
           issue-number: ${{ github.event.issue.number }}
           body: |
@@ -276,7 +277,7 @@ jobs:
     #Add approval comment if approval_state == Approved
       - name: Add auto approval comment
         if: env.APPROVAL_STATE == 'Approved'
-        uses: peter-evans/create-or-update-comment@v3.1.0
+        uses: peter-evans/create-or-update-comment@v4.0.0
         with:
           issue-number: ${{ github.event.issue.number }}
           body: |
@@ -326,6 +327,7 @@ jobs:
         run: ./scripts/aks/send-slack-message.sh
         env:
           SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK }}
+          SLACK_TOKEN: ${{ secrets.AUTO_SHUTDOWN_OAUTH_TOKEN }}
           ISSUE_TITLE: ${{ github.event.issue.title }}
           CHANGE_JIRA_ID: ${{ env.CHANGE_JIRA_ID }}
           REQUEST_URL: ${{ env.REQUEST_URL }}

--- a/.github/workflows/parsegithubissue.yaml
+++ b/.github/workflows/parsegithubissue.yaml
@@ -266,6 +266,7 @@ jobs:
           issue-number: ${{ github.event.issue.number }}
           body: |
             Due to the level of cost associated with this request, an approval will be required from any additional person. Note, you cannot approve your own request.
+            An approval is provided by adding the "Approved" label to this GitHub issue. See [Review Process](https://github.com/hmcts/auto-shutdown?tab=readme-ov-file#shutdown-exclusion-request---review-process) for additional information.
 
     #If approved label is applued, set approval variables.
       - name: set approved status

--- a/.github/workflows/parsegithubissue.yaml
+++ b/.github/workflows/parsegithubissue.yaml
@@ -12,6 +12,7 @@ env:
   SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
   APPROVAL_STATE: "Pending Approval"
   APPROVAL_COMMENT: "Pending Approval"
+  SLACK_TOKEN: ${{ secrets.AUTO_SHUTDOWN_OAUTH_TOKEN }}
 permissions:
   id-token: write
 jobs:
@@ -184,7 +185,6 @@ jobs:
         run: ./scripts/aks/send-slack-message.sh
         env:
           SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK }}
-          SLACK_TOKEN: ${{ secrets.AUTO_SHUTDOWN_OAUTH_TOKEN }}
           ISSUE_TITLE: ${{ github.event.issue.title }}
           CHANGE_JIRA_ID: ${{ env.CHANGE_JIRA_ID }}
           REQUEST_URL: ${{ env.REQUEST_URL }}
@@ -328,7 +328,6 @@ jobs:
         run: ./scripts/aks/send-slack-message.sh
         env:
           SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK }}
-          SLACK_TOKEN: ${{ secrets.AUTO_SHUTDOWN_OAUTH_TOKEN }}
           ISSUE_TITLE: ${{ github.event.issue.title }}
           CHANGE_JIRA_ID: ${{ env.CHANGE_JIRA_ID }}
           REQUEST_URL: ${{ env.REQUEST_URL }}

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Currently, anyone other than the requester can be an approver. The main purpose 
 Requests should only be approved when the shutdown exclusion is necessary and for the appropriate amount of time.
 
 You should check:
-- Request has an appropriate Change or JIRA reference ID
+- Request has an appropriate Change or Jira reference ID
 - The start and end dates of the request are the minimum required, see below example.
 - Only the necessary enviornments have been included in the request. Note: If you need AAT / Staging then you may want to also select PTL for Jenkins and Preview / Dev if you need to do a pull request
 

--- a/issues_list.json
+++ b/issues_list.json
@@ -60,20 +60,6 @@
         "issue_link": "https://github.com/hmcts/auto-shutdown/issues/413"
     },
     {
-        "start_date": "04-04-2024",
-        "end_date": "04-04-2024",
-        "request_type": "stop",
-        "environment": [
-            "AAT / Staging",
-            "Preview / Dev",
-            "PTL"
-        ],
-        "business_area": "cft",
-        "change_jira_id": "https://tools.hmcts.net/jira/browse/PRL-5482",
-        "stay_on_late": "Yes",
-        "issue_link": "https://github.com/hmcts/auto-shutdown/issues/417"
-    },
-    {
         "start_date": "05-04-2024",
         "end_date": "08-04-2024",
         "request_type": "stop",

--- a/scripts/aks/send-slack-message.sh
+++ b/scripts/aks/send-slack-message.sh
@@ -6,7 +6,7 @@ request_url_link="*<$REQUEST_URL|$CHANGE_JIRA_ID>*"
 request_title_link="*<$REQUEST_URL|$ISSUE_TITLE>*"
 current_date=$(get_current_date)
 environment_field=$(echo "$ENVIRONMENT" | sed 's/\[//; s/\]//; s/"//g')
-slack_username=$(get_slack_displayname_from_github_username $REQUESTER $SLACK_TOKEN)
+slack_username=$(get_slack_displayname_from_github_username $REQUESTER)
 
 # Use jq with variables
 jq --arg issue_url "$request_url_link" \

--- a/scripts/aks/send-slack-message.sh
+++ b/scripts/aks/send-slack-message.sh
@@ -6,6 +6,7 @@ request_url_link="*<$REQUEST_URL|$CHANGE_JIRA_ID>*"
 request_title_link="*<$REQUEST_URL|$ISSUE_TITLE>*"
 current_date=$(get_current_date)
 environment_field=$(echo "$ENVIRONMENT" | sed 's/\[//; s/\]//; s/"//g')
+slack_username=$(get_slack_displayname_from_github_username $REQUESTER $SLACK_TOKEN)
 
 # Use jq with variables
 jq --arg issue_url "$request_url_link" \
@@ -14,11 +15,10 @@ jq --arg issue_url "$request_url_link" \
    --arg environment "$environment_field" \
    --arg start_date "$START_DATE" \
    --arg end_date "$END_DATE" \
-   --arg requester "$REQUESTER" \
+   --arg requester "$slack_username" \
    --arg current_date "$current_date" \
    --arg cost_value "£$COST_DETAILS_FORMATTED" \
    --arg status "$APPROVAL_COMMENT" \
-   --arg issue_ID "$CHANGE_JIRA_ID" \
    --arg raw_issue_url "$REQUEST_URL" \
    '.blocks[0].text.text |= $issue_title | 
     .blocks[1].fields[0].text |= "*Business Area:*\n\($business_area)" |
@@ -29,7 +29,7 @@ jq --arg issue_url "$request_url_link" \
     .blocks[1].fields[5].text |= "*Submitted:*\n\($current_date)" |
     .blocks[1].fields[6].text |= "*Value:*\n\($cost_value)" |
     .blocks[1].fields[7].text |= "*Status:*\n\($status)" |
-    .blocks[2].elements[0].text.text |= "Review \($issue_ID)" |
+    .blocks[2].elements[0].text.text |= "Review Request" |
     .blocks[2].elements[0].url |= $raw_issue_url' scripts/aks/message-template.json > slack-payload.json
 
 MESSAGE=$(< slack-payload.json)

--- a/scripts/common/common-functions.sh
+++ b/scripts/common/common-functions.sh
@@ -114,7 +114,6 @@ get_request_type() {
 
 get_slack_displayname_from_github_username() {
     local github_username="$1"
-    local SLACK_TOKEN=$2
     
     # Using curl to fetch content from github-slack-user-mappings repo
     local user_mappings=$(curl -sS "https://raw.githubusercontent.com/hmcts/github-slack-user-mappings/master/slack.json")

--- a/scripts/common/common-functions.sh
+++ b/scripts/common/common-functions.sh
@@ -45,7 +45,7 @@ function is_late_night_run() {
   if [[ $(get_current_hour) -gt 20 ]]; then
     echo "true"
   else
-    echo "true"
+    echo "false"
   fi
 }
 
@@ -110,4 +110,31 @@ get_request_type() {
   if [[ -z $request_type || $request_type == "null" ]]; then
     request_type="stop"
   fi
+}
+
+get_slack_displayname_from_github_username() {
+    local github_username="$1"
+    local SLACK_TOKEN=$2
+    
+    # Using curl to fetch content from github-slack-user-mappings repo
+    local user_mappings=$(curl -sS "https://raw.githubusercontent.com/hmcts/github-slack-user-mappings/master/slack.json")
+    
+    # Filtering JSON data based on GitHub field using jq
+    local slack_id=$(echo "$user_mappings" | jq -r ".users[] | select(.github == \"$github_username\") | .slack")
+ 
+    if [[ -z $slack_id ]]; then
+        #setting output to input GitHub username as slack mapping doesn't exist.
+        echo $github_username
+    else
+        # Slack API request to get user information based on ID.
+        local url="https://slack.com/api/users.profile.get?include_labels=real_name&user=$slack_id&pretty=1"
+        local data='{"user": "'"$slack_id"'"}'
+        local response=$(curl -s -X POST \
+            -H "Authorization: Bearer $SLACK_TOKEN" \
+            -H "Content-Type: application/json" \
+            -d "$data" "$url")
+
+        local slack_real_name=$(echo "$response" | jq -r '.profile.real_name')
+        echo $slack_real_name
+    fi
 }


### PR DESCRIPTION
### Jira link (if applicable)
DTSPO-17194


### Change description ###
Slack messages will now output slack "real names" rather than ambiguous GitHub usernames, making requesters easier to identify.


## Bug fixes & minor updates ##
- Fixed a bug where nightly shutdown run would always be treated as the 23:00 run, even at 20:00.
- Removed dynamic link button which included issue ID, replaced with static "Review Request" button.
- JIRA reworded to Jira
- Approval comment now contains more information including a like to the review process.
- Marketplace actions upgrades.

## Still to come ##
- Some additional work is required to enable the conversion of approver name from GitHub to Slack.
