### PR TITLE
DTSPO-15447 - Separate step for exit on cancel

### DIFF
--- a/.github/workflows/parsegithubissue.yaml
+++ b/.github/workflows/parsegithubissue.yaml
@@ -49,6 +49,11 @@ jobs:
           commit_tree_url=$(gh browse -c -n)
           commit_url=${commit_tree_url/tree/commit}
           echo "COMMIT_URL=$(echo $commit_url)" >> $GITHUB_ENV
+
+    #Exit workflow if canceled
+      - name: Exit workflow
+        if: contains(github.event.issue.labels.*.name, 'cancel') && github.event.action == 'labeled'
+        run: |
           exit 0
 
     #Adds label for user feedback


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/DTSPO-15447

### Change description ###
Add separate step for exit after cancellation
`exit 0` in commit step did not take effect on recent run

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
