### PR TITLE
DTSPO-15447 - Separate cancel action

### DIFF
--- a/.github/workflows/cancel-github-issue.yaml
+++ b/.github/workflows/cancel-github-issue.yaml
@@ -1,0 +1,37 @@
+name: Cancel issue
+run-name: ${{ github.actor }} - cancel issue:${{ github.event.issue.number }}
+on:
+  issues:
+    types:
+      - opened
+      - edited
+      - labeled
+  workflow_dispatch:
+env:
+  GH_TOKEN: ${{ secrets.PLATFORM_USER_TOKEN }}
+  SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+  APPROVAL_STATE: "Pending Approval"
+  APPROVAL_COMMENT: "Pending Approval"
+  SLACK_TOKEN: ${{ secrets.AUTO_SHUTDOWN_OAUTH_TOKEN }}
+permissions:
+  id-token: write
+jobs:
+  process-request:
+    permissions: write-all
+    runs-on: ubuntu-latest
+    if: github.event.issue.user.login != 'renovate[bot]' && contains(github.event.issue.labels.*.name, 'cancel')
+    steps:
+     #Allows workflow to access repo
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: '0'
+          token: ${{ env.GH_TOKEN }}
+          
+     #Check if the "cancel" label is added
+      - name: Check for cancel label
+        run: |
+          # Logic to remove entry from issues_list.json
+          python ./scripts/remove_entry.py ${{ github.event.issue.number }}
+          # Exit the workflow
+          exit 0

--- a/.github/workflows/parsegithubissue.yaml
+++ b/.github/workflows/parsegithubissue.yaml
@@ -19,7 +19,7 @@ jobs:
   process-request:
     permissions: write-all
     runs-on: ubuntu-latest
-    if: github.event.issue.user.login != 'renovate[bot]'
+    if: github.event.issue.user.login != 'renovate[bot]' && !contains(github.event.issue.labels.*.name, 'cancel')
     steps:
     #Allows workflow to access repo
       - name: Checkout


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/DTSPO-15447

### Change description ###
Exiting workflow doesn't seem to be working even though I was sure it was working during testing
Updating to use a separate action for cancelling an issue that will run only when the `cancel` label is added
Regular parsing action will run when any other label is added

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
