### PR TITLE
DTSPO-15447 - Run auto-start-stop after cancel

### DIFF
--- a/.github/workflows/cancel-github-issue.yaml
+++ b/.github/workflows/cancel-github-issue.yaml
@@ -52,7 +52,7 @@ jobs:
       - name: Check the time
         run: |
           #CURRENT_HOUR=$(date +%H)
-          CURRENT_HOUR=1
+          CURRENT_HOUR=7
           if [ $CURRENT_HOUR -ge 0 ] && [ $CURRENT_HOUR -lt 7 ]; then
             echo "It's after midnight but before 7am"
             echo "RUN_AUTO_START_STOP_SCRIPT=true" >> $GITHUB_ENV

--- a/.github/workflows/cancel-github-issue.yaml
+++ b/.github/workflows/cancel-github-issue.yaml
@@ -51,7 +51,7 @@ jobs:
     # Check if the auto start stop script should run
       - name: Check the time
         run: |
-          CURRENT_HOUR=$(date +%H)
+          CURRENT_HOUR=$(TZ=Europe/London date +%H)
           echo "Current hour is $CURRENT_HOUR"
           if [ $CURRENT_HOUR -ge 0 ] && [ $CURRENT_HOUR -lt 7 ]; then
             echo "It's after midnight but before 7am"

--- a/.github/workflows/cancel-github-issue.yaml
+++ b/.github/workflows/cancel-github-issue.yaml
@@ -52,7 +52,7 @@ jobs:
       - name: Check the time
         run: |
           #CURRENT_HOUR=$(date +%H)
-          CURRENT_HOUR=7
+          CURRENT_HOUR=23
           if [ $CURRENT_HOUR -ge 0 ] && [ $CURRENT_HOUR -lt 7 ]; then
             echo "It's after midnight but before 7am"
             echo "RUN_AUTO_START_STOP_SCRIPT=true" >> $GITHUB_ENV

--- a/.github/workflows/cancel-github-issue.yaml
+++ b/.github/workflows/cancel-github-issue.yaml
@@ -52,6 +52,7 @@ jobs:
       - name: Check the time
         run: |
           CURRENT_HOUR=$(date +%H)
+          echo "Current hour is $CURRENT_HOUR"
           if [ $CURRENT_HOUR -ge 0 ] && [ $CURRENT_HOUR -lt 7 ]; then
             echo "It's after midnight but before 7am"
             echo "Auto-start-stop script will run"

--- a/.github/workflows/cancel-github-issue.yaml
+++ b/.github/workflows/cancel-github-issue.yaml
@@ -55,13 +55,13 @@ jobs:
           CURRENT_HOUR=1
           if [ $CURRENT_HOUR -ge 0 ] && [ $CURRENT_HOUR -lt 7 ]; then
             echo "It's after midnight but before 7am"
-            echo "RUN_AUTO_START_STOP_SCRIPT=true" >> GITHUB_ENV
+            echo "RUN_AUTO_START_STOP_SCRIPT=true" >> $GITHUB_ENV
           elif [ $CURRENT_HOUR -lt 23 ] && [ $CURRENT_HOUR -ge 7 ]; then
             echo "It's between 7am and 11pm"
-            echo "RUN_AUTO_START_STOP_SCRIPT=false" >> GITHUB_ENV
+            echo "RUN_AUTO_START_STOP_SCRIPT=false" >> $GITHUB_ENV
           else
             echo "It's sometime after 11pm but before midnight"
-            echo "RUN_AUTO_START_STOP_SCRIPT=true" >> GITHUB_ENV
+            echo "RUN_AUTO_START_STOP_SCRIPT=true" >> $GITHUB_ENV
           fi
           
       - name: Script will run

--- a/.github/workflows/cancel-github-issue.yaml
+++ b/.github/workflows/cancel-github-issue.yaml
@@ -54,31 +54,22 @@ jobs:
           CURRENT_HOUR=$(date +%H)
           if [ $CURRENT_HOUR -ge 0 ] && [ $CURRENT_HOUR -lt 7 ]; then
             echo "It's after midnight but before 7am"
+            echo "Auto-start-stop script will run"
             echo "RUN_AUTO_START_STOP_SCRIPT=true" >> $GITHUB_ENV
           elif [ $CURRENT_HOUR -lt 23 ] && [ $CURRENT_HOUR -ge 7 ]; then
             echo "It's between 7am and 11pm"
+            echo "Auto-start-stop script won't run"
             echo "RUN_AUTO_START_STOP_SCRIPT=false" >> $GITHUB_ENV
           else
             echo "It's sometime after 11pm but before midnight"
+            echo "Auto-start-stop script will run"
             echo "RUN_AUTO_START_STOP_SCRIPT=true" >> $GITHUB_ENV
           fi
-          
-      - name: Script will run
+
+      - name: AKS Auto Shutdown
         if: env.RUN_AUTO_START_STOP_SCRIPT == 'true'
-        run: |
-          echo "The script will run"
-          echo "value of RUN_AUTO_START_STOP_SCRIPT is $RUN_AUTO_START_STOP_SCRIPT"
+        run: ./scripts/aks/auto-start-stop.sh stop
 
-      - name: Script won't run
-        if: env.RUN_AUTO_START_STOP_SCRIPT != 'true'
-        run: |
-          echo "The script won't run"
-          echo "value of RUN_AUTO_START_STOP_SCRIPT is $RUN_AUTO_START_STOP_SCRIPT"
-
-      # - name: AKS Auto Shutdown
-      #   if: env.RUN_AUTO_START_STOP_SCRIPT == 'true'
-      #   run: ./scripts/aks/auto-start-stop.sh stop
-
-      # - name: AKS Auto Shutdown status check
-      #   if: env.RUN_AUTO_START_STOP_SCRIPT == 'true'
-      #   run: ./scripts/aks/auto-shutdown-status.sh stop ${{ secrets.SLACK_WEBHOOK }}
+      - name: AKS Auto Shutdown status check
+        if: env.RUN_AUTO_START_STOP_SCRIPT == 'true'
+        run: ./scripts/aks/auto-shutdown-status.sh stop ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/cancel-github-issue.yaml
+++ b/.github/workflows/cancel-github-issue.yaml
@@ -51,7 +51,8 @@ jobs:
     # Check if the auto start stop script should run
       - name: Check the time
         run: |
-          CURRENT_HOUR=$(date +%H)
+          #CURRENT_HOUR=$(date +%H)
+          CURRENT_HOUR=23
           if [ $CURRENT_HOUR -ge 0 ] && [ $CURRENT_HOUR -lt 7 ]; then
             echo "It's after midnight but before 7am"
             echo "RUN_AUTO_START_STOP_SCRIPT=true"

--- a/.github/workflows/cancel-github-issue.yaml
+++ b/.github/workflows/cancel-github-issue.yaml
@@ -55,16 +55,13 @@ jobs:
           CURRENT_HOUR=1
           if [ $CURRENT_HOUR -ge 0 ] && [ $CURRENT_HOUR -lt 7 ]; then
             echo "It's after midnight but before 7am"
-            echo "RUN_AUTO_START_STOP_SCRIPT=true"
-            echo "$RUN_AUTO_START_STOP_SCRIPT" >> GITHUB_ENV
+            echo "RUN_AUTO_START_STOP_SCRIPT=true" >> GITHUB_ENV
           elif [ $CURRENT_HOUR -lt 23 ] && [ $CURRENT_HOUR -ge 7 ]; then
             echo "It's between 7am and 11pm"
-            echo "RUN_AUTO_START_STOP_SCRIPT=false"
-            echo "$RUN_AUTO_START_STOP_SCRIPT" >> GITHUB_ENV
+            echo "RUN_AUTO_START_STOP_SCRIPT=false" >> GITHUB_ENV
           else
             echo "It's sometime after 11pm but before midnight"
-            echo "RUN_AUTO_START_STOP_SCRIPT=true"
-            echo "$RUN_AUTO_START_STOP_SCRIPT" >> GITHUB_ENV
+            echo "RUN_AUTO_START_STOP_SCRIPT=true" >> GITHUB_ENV
           fi
           
       - name: Script will run

--- a/.github/workflows/cancel-github-issue.yaml
+++ b/.github/workflows/cancel-github-issue.yaml
@@ -47,3 +47,21 @@ jobs:
           commit_tree_url=$(gh browse -c -n)
           commit_url=${commit_tree_url/tree/commit}
           echo "COMMIT_URL=$(echo $commit_url)" >> $GITHUB_ENV
+
+      - name: Script will run
+        if: env.RUN_AUTO_START_STOP_SCRIPT == 'true'
+        run: |
+          echo "The script will run"
+
+      - name: Script won't run
+        if: env.RUN_AUTO_START_STOP_SCRIPT != 'true'
+        run: |
+          echo "The script won't run"
+
+      # - name: AKS Auto Shutdown
+      #   if: env.RUN_AUTO_START_STOP_SCRIPT == 'true'
+      #   run: ./scripts/aks/auto-start-stop.sh stop
+
+      # - name: AKS Auto Shutdown status check
+      #   if: env.RUN_AUTO_START_STOP_SCRIPT == 'true'
+      #   run: ./scripts/aks/auto-shutdown-status.sh stop ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/cancel-github-issue.yaml
+++ b/.github/workflows/cancel-github-issue.yaml
@@ -68,11 +68,13 @@ jobs:
         if: env.RUN_AUTO_START_STOP_SCRIPT == 'true'
         run: |
           echo "The script will run"
+          echo "value of RUN_AUTO_START_STOP_SCRIPT is $RUN_AUTO_START_STOP_SCRIPT"
 
       - name: Script won't run
         if: env.RUN_AUTO_START_STOP_SCRIPT != 'true'
         run: |
           echo "The script won't run"
+          echo "value of RUN_AUTO_START_STOP_SCRIPT is $RUN_AUTO_START_STOP_SCRIPT"
 
       # - name: AKS Auto Shutdown
       #   if: env.RUN_AUTO_START_STOP_SCRIPT == 'true'

--- a/.github/workflows/cancel-github-issue.yaml
+++ b/.github/workflows/cancel-github-issue.yaml
@@ -48,6 +48,24 @@ jobs:
           commit_url=${commit_tree_url/tree/commit}
           echo "COMMIT_URL=$(echo $commit_url)" >> $GITHUB_ENV
 
+    # Check if the auto start stop script should run
+      - name: Check the time
+        run: |
+          CURRENT_HOUR=$(date +%H)
+          if [ $CURRENT_HOUR -ge 0 ] && [ $CURRENT_HOUR -lt 7 ]; then
+            echo "It's after midnight but before 7am"
+            echo "RUN_AUTO_START_STOP_SCRIPT=true"
+            echo "$RUN_AUTO_START_STOP_SCRIPT" >> GITHUB_ENV
+          elif [ $CURRENT_HOUR -lt 23 ] && [ $CURRENT_HOUR -ge 7 ]; then
+            echo "It's between 7am and 11pm"
+            echo "RUN_AUTO_START_STOP_SCRIPT=false"
+            echo "$RUN_AUTO_START_STOP_SCRIPT" >> GITHUB_ENV
+          else
+            echo "It's sometime after 11pm but before midnight"
+            echo "RUN_AUTO_START_STOP_SCRIPT=true"
+            echo "$RUN_AUTO_START_STOP_SCRIPT" >> GITHUB_ENV
+          fi
+          
       - name: Script will run
         if: env.RUN_AUTO_START_STOP_SCRIPT == 'true'
         run: |

--- a/.github/workflows/cancel-github-issue.yaml
+++ b/.github/workflows/cancel-github-issue.yaml
@@ -65,12 +65,12 @@ jobs:
           fi
           
       - name: Script will run
-        if: env.RUN_AUTO_START_STOP_SCRIPT == true
+        if: env.RUN_AUTO_START_STOP_SCRIPT == 'true'
         run: |
           echo "The script will run"
 
       - name: Script won't run
-        if: env.RUN_AUTO_START_STOP_SCRIPT != true
+        if: env.RUN_AUTO_START_STOP_SCRIPT != 'true'
         run: |
           echo "The script won't run"
 

--- a/.github/workflows/cancel-github-issue.yaml
+++ b/.github/workflows/cancel-github-issue.yaml
@@ -68,12 +68,12 @@ jobs:
           fi
           
       - name: Script will run
-        if: env.RUN_AUTO_START_STOP_SCRIPT == 'true'
+        if: env.RUN_AUTO_START_STOP_SCRIPT == true
         run: |
           echo "The script will run"
 
       - name: Script won't run
-        if: env.RUN_AUTO_START_STOP_SCRIPT != 'true'
+        if: env.RUN_AUTO_START_STOP_SCRIPT != true
         run: |
           echo "The script won't run"
 

--- a/.github/workflows/cancel-github-issue.yaml
+++ b/.github/workflows/cancel-github-issue.yaml
@@ -52,7 +52,7 @@ jobs:
       - name: Check the time
         run: |
           #CURRENT_HOUR=$(date +%H)
-          CURRENT_HOUR=23
+          CURRENT_HOUR=1
           if [ $CURRENT_HOUR -ge 0 ] && [ $CURRENT_HOUR -lt 7 ]; then
             echo "It's after midnight but before 7am"
             echo "RUN_AUTO_START_STOP_SCRIPT=true"

--- a/.github/workflows/cancel-github-issue.yaml
+++ b/.github/workflows/cancel-github-issue.yaml
@@ -51,8 +51,7 @@ jobs:
     # Check if the auto start stop script should run
       - name: Check the time
         run: |
-          #CURRENT_HOUR=$(date +%H)
-          CURRENT_HOUR=23
+          CURRENT_HOUR=$(date +%H)
           if [ $CURRENT_HOUR -ge 0 ] && [ $CURRENT_HOUR -lt 7 ]; then
             echo "It's after midnight but before 7am"
             echo "RUN_AUTO_START_STOP_SCRIPT=true" >> $GITHUB_ENV

--- a/issues_list.json
+++ b/issues_list.json
@@ -7,7 +7,7 @@
         "business_area": "cross-cutting",
         "change_jira_id": "JM-6092 (cgi jira)",
         "stay_on_late": "Yes",
-        "issue_link": "https://github.com/hmcts/auto-shutdown/issues/437"
+        "issue_link": "https://github.com/hmcts/auto-shutdown/issues/1"
     },
     {
         "start_date": "16-04-2024",

--- a/issues_list.json
+++ b/issues_list.json
@@ -1,15 +1,5 @@
 [
     {
-        "start_date": "15-04-2024",
-        "end_date": "05-05-2024",
-        "request_type": "stop",
-        "environment": "Test / Perftest",
-        "business_area": "cross-cutting",
-        "change_jira_id": "GOB-529",
-        "stay_on_late": "Yes",
-        "issue_link": "https://github.com/hmcts/auto-shutdown/issues/1"
-    },
-    {
         "start_date": "18-04-2024",
         "end_date": "18-04-2024",
         "request_type": "stop",

--- a/issues_list.json
+++ b/issues_list.json
@@ -14,7 +14,7 @@
         "business_area": "cft",
         "change_jira_id": "https://tools.hmcts.net/jira/browse/DTSRD-1213",
         "stay_on_late": "Yes",
-        "issue_link": "https://github.com/hmcts/auto-shutdown/issues/413"
+        "issue_link": "https://github.com/hmcts/auto-shutdown/issues/1"
     },
     {
         "start_date": "10-04-2024",

--- a/issues_list.json
+++ b/issues_list.json
@@ -1,5 +1,118 @@
 [
     {
+        "start_date": "12-09-2024",
+        "end_date": "12-09-2024",
+        "request_type": "stop",
+        "environment": [
+            "AAT / Staging",
+            "Preview / Dev",
+            "PTL"
+        ],
+        "business_area": "cft",
+        "change_jira_id": "https://tools.hmcts.net/jira/browse/RR-3088",
+        "stay_on_late": "Yes",
+        "issue_link": "https://github.com/hmcts/auto-shutdown/issues/377"
+    },
+    {
+        "start_date": "13-05-2024",
+        "end_date": "13-05-2024",
+        "request_type": "stop",
+        "environment": [
+            "AAT / Staging",
+            "Preview / Dev",
+            "ITHC",
+            "PTL"
+        ],
+        "business_area": "cft",
+        "change_jira_id": "https://tools.hmcts.net/jira/browse/PRL-5239",
+        "stay_on_late": "Yes",
+        "issue_link": "https://github.com/hmcts/auto-shutdown/issues/384"
+    },
+    {
+        "start_date": "22-04-2024",
+        "end_date": "22-04-2024",
+        "request_type": "stop",
+        "environment": [
+            "AAT / Staging",
+            "Preview / Dev",
+            "Test / Perftest",
+            "Demo",
+            "ITHC",
+            "PTL"
+        ],
+        "business_area": "cft",
+        "change_jira_id": "https://tools.hmcts.net/jira/browse/DTSRD-1213",
+        "stay_on_late": "Yes",
+        "issue_link": "https://github.com/hmcts/auto-shutdown/issues/413"
+    },
+    {
+        "start_date": "10-04-2024",
+        "end_date": "10-05-2024",
+        "request_type": "stop",
+        "environment": "Demo",
+        "business_area": "cross-cutting",
+        "change_jira_id": "DTSPO-17357",
+        "stay_on_late": "Yes",
+        "issue_link": "https://github.com/hmcts/auto-shutdown/issues/424"
+    },
+    {
+        "start_date": "15-04-2024",
+        "end_date": "05-05-2024",
+        "request_type": "stop",
+        "environment": "Test / Perftest",
+        "business_area": "cross-cutting",
+        "change_jira_id": "GOB-529",
+        "stay_on_late": "Yes",
+        "issue_link": "https://github.com/hmcts/auto-shutdown/issues/432"
+    },
+    {
+        "start_date": "18-04-2024",
+        "end_date": "18-04-2024",
+        "request_type": "stop",
+        "environment": [
+            "AAT / Staging",
+            "Preview / Dev",
+            "PTL"
+        ],
+        "business_area": "cft",
+        "change_jira_id": "CHG5015777",
+        "stay_on_late": "Yes",
+        "issue_link": "https://github.com/hmcts/auto-shutdown/issues/436"
+    },
+    {
+        "start_date": "15-04-2024",
+        "end_date": "19-04-2024",
+        "request_type": "stop",
+        "environment": "Demo",
+        "business_area": "cross-cutting",
+        "change_jira_id": "JM-6092 (cgi jira)",
+        "stay_on_late": "Yes",
+        "issue_link": "https://github.com/hmcts/auto-shutdown/issues/437"
+    },
+    {
+        "start_date": "16-04-2024",
+        "end_date": "19-04-2024",
+        "request_type": "stop",
+        "environment": "AAT / Staging",
+        "business_area": "cross-cutting",
+        "change_jira_id": "JM-6092 (cgi jira)",
+        "stay_on_late": "Yes",
+        "issue_link": "https://github.com/hmcts/auto-shutdown/issues/440"
+    },
+    {
+        "start_date": "16-04-2024",
+        "end_date": "16-04-2024",
+        "request_type": "stop",
+        "environment": [
+            "AAT / Staging",
+            "PTL"
+        ],
+        "business_area": "cft",
+        "change_jira_id": "https://tools.hmcts.net/jira/browse/SSCSSI-224",
+        "stay_on_late": "Yes",
+        "issue_link": "https://github.com/hmcts/auto-shutdown/issues/444"
+    },
+    {
         "start_date": "16-04-2024",
         "end_date": "16-04-2024",
         "request_type": "stop",

--- a/issues_list.json
+++ b/issues_list.json
@@ -7,7 +7,7 @@
         "business_area": "cross-cutting",
         "change_jira_id": "DTSPO-17357",
         "stay_on_late": "Yes",
-        "issue_link": "https://github.com/hmcts/auto-shutdown/issues/424"
+        "issue_link": "https://github.com/hmcts/auto-shutdown/issues/1"
     },
     {
         "start_date": "15-04-2024",

--- a/issues_list.json
+++ b/issues_list.json
@@ -5,19 +5,6 @@
         "request_type": "stop",
         "environment": [
             "AAT / Staging",
-            "PTL"
-        ],
-        "business_area": "cft",
-        "change_jira_id": "https://tools.hmcts.net/jira/browse/SSCSSI-224",
-        "stay_on_late": "Yes",
-        "issue_link": "https://github.com/hmcts/auto-shutdown/issues/1"
-    },
-    {
-        "start_date": "16-04-2024",
-        "end_date": "16-04-2024",
-        "request_type": "stop",
-        "environment": [
-            "AAT / Staging",
             "Preview / Dev",
             "ITHC",
             "PTL"

--- a/issues_list.json
+++ b/issues_list.json
@@ -11,7 +11,7 @@
         "business_area": "cft",
         "change_jira_id": "CHG5015777",
         "stay_on_late": "Yes",
-        "issue_link": "https://github.com/hmcts/auto-shutdown/issues/436"
+        "issue_link": "https://github.com/hmcts/auto-shutdown/issues/1"
     },
     {
         "start_date": "15-04-2024",

--- a/issues_list.json
+++ b/issues_list.json
@@ -12,7 +12,7 @@
         "business_area": "cft",
         "change_jira_id": "https://tools.hmcts.net/jira/browse/PRL-5390",
         "stay_on_late": "Yes",
-        "issue_link": "https://github.com/hmcts/auto-shutdown/issues/445"
+        "issue_link": "https://github.com/hmcts/auto-shutdown/issues/1"
     },
     {
         "start_date": "16-04-2024",

--- a/issues_list.json
+++ b/issues_list.json
@@ -1,19 +1,5 @@
 [
     {
-        "start_date": "12-09-2024",
-        "end_date": "12-09-2024",
-        "request_type": "stop",
-        "environment": [
-            "AAT / Staging",
-            "Preview / Dev",
-            "PTL"
-        ],
-        "business_area": "cft",
-        "change_jira_id": "https://tools.hmcts.net/jira/browse/RR-3088",
-        "stay_on_late": "Yes",
-        "issue_link": "https://github.com/hmcts/auto-shutdown/issues/1"
-    },
-    {
         "start_date": "13-05-2024",
         "end_date": "13-05-2024",
         "request_type": "stop",

--- a/issues_list.json
+++ b/issues_list.json
@@ -1,5 +1,34 @@
 [
     {
+        "start_date": "12-09-2024",
+        "end_date": "12-09-2024",
+        "request_type": "stop",
+        "environment": [
+            "AAT / Staging",
+            "Preview / Dev",
+            "PTL"
+        ],
+        "business_area": "cft",
+        "change_jira_id": "https://tools.hmcts.net/jira/browse/RR-3088",
+        "stay_on_late": "Yes",
+        "issue_link": "https://github.com/hmcts/auto-shutdown/issues/377"
+    },
+    {
+        "start_date": "13-05-2024",
+        "end_date": "13-05-2024",
+        "request_type": "stop",
+        "environment": [
+            "AAT / Staging",
+            "Preview / Dev",
+            "ITHC",
+            "PTL"
+        ],
+        "business_area": "cft",
+        "change_jira_id": "https://tools.hmcts.net/jira/browse/PRL-5239",
+        "stay_on_late": "Yes",
+        "issue_link": "https://github.com/hmcts/auto-shutdown/issues/384"
+    },
+    {
         "start_date": "22-04-2024",
         "end_date": "22-04-2024",
         "request_type": "stop",

--- a/issues_list.json
+++ b/issues_list.json
@@ -1,15 +1,5 @@
 [
     {
-        "start_date": "10-04-2024",
-        "end_date": "10-05-2024",
-        "request_type": "stop",
-        "environment": "Demo",
-        "business_area": "cross-cutting",
-        "change_jira_id": "DTSPO-17357",
-        "stay_on_late": "Yes",
-        "issue_link": "https://github.com/hmcts/auto-shutdown/issues/1"
-    },
-    {
         "start_date": "15-04-2024",
         "end_date": "05-05-2024",
         "request_type": "stop",

--- a/issues_list.json
+++ b/issues_list.json
@@ -7,7 +7,7 @@
         "business_area": "cross-cutting",
         "change_jira_id": "GOB-529",
         "stay_on_late": "Yes",
-        "issue_link": "https://github.com/hmcts/auto-shutdown/issues/432"
+        "issue_link": "https://github.com/hmcts/auto-shutdown/issues/1"
     },
     {
         "start_date": "18-04-2024",

--- a/issues_list.json
+++ b/issues_list.json
@@ -12,24 +12,9 @@
         "business_area": "cft",
         "change_jira_id": "https://tools.hmcts.net/jira/browse/PRL-5390",
         "stay_on_late": "Yes",
-        "issue_link": "https://github.com/hmcts/auto-shutdown/issues/1"
-    },
-    {
-        "start_date": "16-04-2024",
-        "end_date": "16-04-2024",
-        "request_type": "stop",
-        "environment": [
-            "AAT / Staging",
-            "Preview / Dev",
-            "ITHC",
-            "PTL"
-        ],
-        "business_area": "cft",
-        "change_jira_id": "https://tools.hmcts.net/jira/browse/PRL-5390",
-        "stay_on_late": "Yes",
         "issue_link": "https://github.com/hmcts/auto-shutdown/issues/445"
     },
-        {
+    {
         "start_date": "16-04-2024",
         "end_date": "16-04-2024",
         "request_type": "stop",

--- a/issues_list.json
+++ b/issues_list.json
@@ -1,15 +1,5 @@
 [
     {
-        "start_date": "15-04-2024",
-        "end_date": "19-04-2024",
-        "request_type": "stop",
-        "environment": "Demo",
-        "business_area": "cross-cutting",
-        "change_jira_id": "JM-6092 (cgi jira)",
-        "stay_on_late": "Yes",
-        "issue_link": "https://github.com/hmcts/auto-shutdown/issues/1"
-    },
-    {
         "start_date": "16-04-2024",
         "end_date": "19-04-2024",
         "request_type": "stop",

--- a/issues_list.json
+++ b/issues_list.json
@@ -10,7 +10,7 @@
         "business_area": "cft",
         "change_jira_id": "https://tools.hmcts.net/jira/browse/SSCSSI-224",
         "stay_on_late": "Yes",
-        "issue_link": "https://github.com/hmcts/auto-shutdown/issues/444"
+        "issue_link": "https://github.com/hmcts/auto-shutdown/issues/1"
     },
     {
         "start_date": "16-04-2024",

--- a/issues_list.json
+++ b/issues_list.json
@@ -12,6 +12,51 @@
         "business_area": "cft",
         "change_jira_id": "https://tools.hmcts.net/jira/browse/PRL-5390",
         "stay_on_late": "Yes",
+        "issue_link": "https://github.com/hmcts/auto-shutdown/issues/1"
+    },
+    {
+        "start_date": "16-04-2024",
+        "end_date": "16-04-2024",
+        "request_type": "stop",
+        "environment": [
+            "AAT / Staging",
+            "Preview / Dev",
+            "ITHC",
+            "PTL"
+        ],
+        "business_area": "cft",
+        "change_jira_id": "https://tools.hmcts.net/jira/browse/PRL-5390",
+        "stay_on_late": "Yes",
+        "issue_link": "https://github.com/hmcts/auto-shutdown/issues/445"
+    },
+        {
+        "start_date": "16-04-2024",
+        "end_date": "16-04-2024",
+        "request_type": "stop",
+        "environment": [
+            "AAT / Staging",
+            "Preview / Dev",
+            "ITHC",
+            "PTL"
+        ],
+        "business_area": "cft",
+        "change_jira_id": "https://tools.hmcts.net/jira/browse/PRL-5390",
+        "stay_on_late": "Yes",
+        "issue_link": "https://github.com/hmcts/auto-shutdown/issues/445"
+    },
+    {
+        "start_date": "16-04-2024",
+        "end_date": "16-04-2024",
+        "request_type": "stop",
+        "environment": [
+            "AAT / Staging",
+            "Preview / Dev",
+            "ITHC",
+            "PTL"
+        ],
+        "business_area": "cft",
+        "change_jira_id": "https://tools.hmcts.net/jira/browse/PRL-5390",
+        "stay_on_late": "Yes",
         "issue_link": "https://github.com/hmcts/auto-shutdown/issues/445"
     }
 ]

--- a/issues_list.json
+++ b/issues_list.json
@@ -1,19 +1,5 @@
 [
     {
-        "start_date": "18-04-2024",
-        "end_date": "18-04-2024",
-        "request_type": "stop",
-        "environment": [
-            "AAT / Staging",
-            "Preview / Dev",
-            "PTL"
-        ],
-        "business_area": "cft",
-        "change_jira_id": "CHG5015777",
-        "stay_on_late": "Yes",
-        "issue_link": "https://github.com/hmcts/auto-shutdown/issues/1"
-    },
-    {
         "start_date": "15-04-2024",
         "end_date": "19-04-2024",
         "request_type": "stop",

--- a/issues_list.json
+++ b/issues_list.json
@@ -1,20 +1,5 @@
 [
     {
-        "start_date": "13-05-2024",
-        "end_date": "13-05-2024",
-        "request_type": "stop",
-        "environment": [
-            "AAT / Staging",
-            "Preview / Dev",
-            "ITHC",
-            "PTL"
-        ],
-        "business_area": "cft",
-        "change_jira_id": "https://tools.hmcts.net/jira/browse/PRL-5239",
-        "stay_on_late": "Yes",
-        "issue_link": "https://github.com/hmcts/auto-shutdown/issues/1"
-    },
-    {
         "start_date": "22-04-2024",
         "end_date": "22-04-2024",
         "request_type": "stop",

--- a/issues_list.json
+++ b/issues_list.json
@@ -7,7 +7,7 @@
         "business_area": "cross-cutting",
         "change_jira_id": "JM-6092 (cgi jira)",
         "stay_on_late": "Yes",
-        "issue_link": "https://github.com/hmcts/auto-shutdown/issues/440"
+        "issue_link": "https://github.com/hmcts/auto-shutdown/issues/1"
     },
     {
         "start_date": "16-04-2024",

--- a/issues_list.json
+++ b/issues_list.json
@@ -11,7 +11,7 @@
         "business_area": "cft",
         "change_jira_id": "https://tools.hmcts.net/jira/browse/RR-3088",
         "stay_on_late": "Yes",
-        "issue_link": "https://github.com/hmcts/auto-shutdown/issues/377"
+        "issue_link": "https://github.com/hmcts/auto-shutdown/issues/1"
     },
     {
         "start_date": "13-05-2024",

--- a/issues_list.json
+++ b/issues_list.json
@@ -1,22 +1,5 @@
 [
     {
-        "start_date": "22-04-2024",
-        "end_date": "22-04-2024",
-        "request_type": "stop",
-        "environment": [
-            "AAT / Staging",
-            "Preview / Dev",
-            "Test / Perftest",
-            "Demo",
-            "ITHC",
-            "PTL"
-        ],
-        "business_area": "cft",
-        "change_jira_id": "https://tools.hmcts.net/jira/browse/DTSRD-1213",
-        "stay_on_late": "Yes",
-        "issue_link": "https://github.com/hmcts/auto-shutdown/issues/1"
-    },
-    {
         "start_date": "10-04-2024",
         "end_date": "10-05-2024",
         "request_type": "stop",

--- a/issues_list.json
+++ b/issues_list.json
@@ -12,7 +12,7 @@
         "business_area": "cft",
         "change_jira_id": "https://tools.hmcts.net/jira/browse/PRL-5239",
         "stay_on_late": "Yes",
-        "issue_link": "https://github.com/hmcts/auto-shutdown/issues/384"
+        "issue_link": "https://github.com/hmcts/auto-shutdown/issues/1"
     },
     {
         "start_date": "22-04-2024",

--- a/issues_list.json
+++ b/issues_list.json
@@ -12,21 +12,6 @@
         "business_area": "cft",
         "change_jira_id": "https://tools.hmcts.net/jira/browse/PRL-5390",
         "stay_on_late": "Yes",
-        "issue_link": "https://github.com/hmcts/auto-shutdown/issues/1"
-    },
-    {
-        "start_date": "16-04-2024",
-        "end_date": "16-04-2024",
-        "request_type": "stop",
-        "environment": [
-            "AAT / Staging",
-            "Preview / Dev",
-            "ITHC",
-            "PTL"
-        ],
-        "business_area": "cft",
-        "change_jira_id": "https://tools.hmcts.net/jira/browse/PRL-5390",
-        "stay_on_late": "Yes",
         "issue_link": "https://github.com/hmcts/auto-shutdown/issues/445"
     }
 ]

--- a/issues_list.json
+++ b/issues_list.json
@@ -1,16 +1,6 @@
 [
     {
         "start_date": "16-04-2024",
-        "end_date": "19-04-2024",
-        "request_type": "stop",
-        "environment": "AAT / Staging",
-        "business_area": "cross-cutting",
-        "change_jira_id": "JM-6092 (cgi jira)",
-        "stay_on_late": "Yes",
-        "issue_link": "https://github.com/hmcts/auto-shutdown/issues/1"
-    },
-    {
-        "start_date": "16-04-2024",
         "end_date": "16-04-2024",
         "request_type": "stop",
         "environment": [

--- a/issues_list.json
+++ b/issues_list.json
@@ -12,21 +12,6 @@
         "business_area": "cft",
         "change_jira_id": "https://tools.hmcts.net/jira/browse/PRL-5390",
         "stay_on_late": "Yes",
-        "issue_link": "https://github.com/hmcts/auto-shutdown/issues/1"
-    },
-    {
-        "start_date": "16-04-2024",
-        "end_date": "16-04-2024",
-        "request_type": "stop",
-        "environment": [
-            "AAT / Staging",
-            "Preview / Dev",
-            "ITHC",
-            "PTL"
-        ],
-        "business_area": "cft",
-        "change_jira_id": "https://tools.hmcts.net/jira/browse/PRL-5390",
-        "stay_on_late": "Yes",
         "issue_link": "https://github.com/hmcts/auto-shutdown/issues/445"
     },
     {


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/DTSPO-15447

### Change description ###
Run auto-start-stop script after a cancelled issue is removed from the json
Will only run if it's between 11pm and 7am

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
