### PR TITLE
DTSPO-17194 - adding logic for slack name conversions

### DIFF
--- a/.github/workflows/parsegithubissue-pr.yaml
+++ b/.github/workflows/parsegithubissue-pr.yaml
@@ -219,6 +219,7 @@ jobs:
           ENVIRONMENT: ${{ env.ENVIRONMENT }}
           REQUESTER: ${{ github.event.pull_request.user.login }}
           APPROVAL_COMMENT: ${{ env.APPROVAL_COMMENT }}
+          REVIEWER: ${{ github.actor }}
 
     #End workflow if approval state == denied
       - name: exit flow if denied
@@ -355,3 +356,4 @@ jobs:
           ENVIRONMENT: ${{ env.ENVIRONMENT }}
           REQUESTER: ${{ github.event.pull_request.user.login }}
           APPROVAL_COMMENT: ${{ env.APPROVAL_COMMENT }}
+          REVIEWER: ${{ github.actor }}

--- a/.github/workflows/parsegithubissue.yaml
+++ b/.github/workflows/parsegithubissue.yaml
@@ -45,13 +45,15 @@ jobs:
     #End workflow if user is equal to requester
       - name: exit flow if approver == requester 
         if: contains(github.event.issue.labels.*.name, 'approved') && github.event.issue.user.login == github.actor || contains(github.event.issue.labels.*.name, 'auto-approved') && github.event.issue.user.login == github.actor
-        run: exit 0
+        run: exit 1
+
+
     #if denied label is applied, set approval environment variables appropriately 
       - name: set denied status
         if: contains(github.event.issue.labels.*.name, 'denied')
         run: |
           echo "APPROVAL_STATE=Denied" >> $GITHUB_ENV
-          echo "APPROVAL_COMMENT=Denied by ${{ github.actor }}" >> $GITHUB_ENV
+          echo "APPROVAL_COMMENT=Denied by" >> $GITHUB_ENV
           
     #if approval state == denied, close issue 
       - name: Close Issue with denied
@@ -167,10 +169,11 @@ jobs:
           ENVIRONMENT: ${{ env.ENVIRONMENT }}
           REQUESTER: ${{ github.event.issue.user.login }}
           APPROVAL_COMMENT: ${{ env.APPROVAL_COMMENT }}
+          REVIEWER: ${{ github.actor }}
     #End workflow if approval state == denied
       - name: exit flow if denied
         if: env.APPROVAL_STATE == 'Denied'
-        run: exit 0
+        run: exit 1
     #Add output of cost calculator as a comment to user
       - name: Add cost details as a comment
         if: env.PROCESS_SUCCESS == 'true' && env.ERROR_IN_COSTS != 'true' && !contains(github.event.issue.labels.*.name, 'approved')
@@ -233,7 +236,7 @@ jobs:
         if: contains(github.event.issue.labels.*.name, 'approved')
         run: |
           echo "APPROVAL_STATE=Approved" >> $GITHUB_ENV
-          echo "APPROVAL_COMMENT=Approved by ${{ github.actor }}" >> $GITHUB_ENV
+          echo "APPROVAL_COMMENT=Approved by" >> $GITHUB_ENV
     #Add approval comment if approval_state == Approved
       - name: Add auto approval comment
         if: env.APPROVAL_STATE == 'Approved'
@@ -292,3 +295,4 @@ jobs:
           ENVIRONMENT: ${{ env.ENVIRONMENT }}
           REQUESTER: ${{ github.event.issue.user.login }}
           APPROVAL_COMMENT: ${{ env.APPROVAL_COMMENT }}
+          REVIEWER: ${{ github.actor }}

--- a/scripts/aks/send-slack-message.sh
+++ b/scripts/aks/send-slack-message.sh
@@ -7,6 +7,14 @@ request_title_link="*<$REQUEST_URL|$ISSUE_TITLE>*"
 current_date=$(get_current_date)
 environment_field=$(echo "$ENVIRONMENT" | sed 's/\[//; s/\]//; s/"//g')
 slack_username=$(get_slack_displayname_from_github_username $REQUESTER)
+slack_reviewer=$(get_slack_displayname_from_github_username $REVIEWER)
+
+# Check if the string contains the specific phrase
+if [[ $APPROVAL_COMMENT == *"Approved by"* || $APPROVAL_COMMENT == *"Denied by"* ]]; then
+    status="$APPROVAL_COMMENT $slack_reviewer"
+else
+    status=$APPROVAL_COMMENT
+fi
 
 # Use jq with variables
 jq --arg issue_url "$request_url_link" \
@@ -18,7 +26,7 @@ jq --arg issue_url "$request_url_link" \
    --arg requester "$slack_username" \
    --arg current_date "$current_date" \
    --arg cost_value "£$COST_DETAILS_FORMATTED" \
-   --arg status "$APPROVAL_COMMENT" \
+   --arg status "$status" \
    --arg raw_issue_url "$REQUEST_URL" \
    '.blocks[0].text.text |= $issue_title | 
     .blocks[1].fields[0].text |= "*Business Area:*\n\($business_area)" |


### PR DESCRIPTION
### Jira link (if applicable)
DTSPO-17194


### Change description ###
adding logic for slack name conversions in the status field of the slack message.

Before:

<img width="230" alt="Screenshot 2024-04-26 at 15 34 46" src="https://github.com/hmcts/auto-shutdown/assets/125922012/707ed170-7feb-441b-970a-ee1a9b6ccc36">

After:

<img width="207" alt="Screenshot 2024-04-26 at 15 35 03" src="https://github.com/hmcts/auto-shutdown/assets/125922012/3a3c9df8-4fd9-4178-8c6e-c8d14aea22bc">


### Bug fix ###
Setting exit codes to 1 instead of 0 to ensure pipeline cancels at the appropriate times. 

