### PR TITLE
Amend pause shutdown dates

### DIFF
--- a/issues_list.json
+++ b/issues_list.json
@@ -72,7 +72,7 @@
     },
     {
         "start_date": "11-06-2024",
-        "end_date": "12-06-2024",
+        "end_date": "11-06-2024",
         "request_type": "stop",
         "environment": [
             "AAT / Staging",


### PR DESCRIPTION
### Jira link (if applicable)



### Change description ###
- Amends the pause shutdown end date for https://github.com/hmcts/auto-shutdown/issues/548 
- Confirmed with the requestor they only need it shutdown for 1 day

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
