### PR TITLE
DTSPO-18502 - correcting found issues

### DIFF
--- a/.github/workflows/appgateway-auto-shutdown.yaml
+++ b/.github/workflows/appgateway-auto-shutdown.yaml
@@ -2,7 +2,7 @@ name: AppGateway-auto-shutdown
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 19 * * *' # Every day at 8pm BST
+    - cron: '0 19,22 * * *' # Every day at 20:00 and 23:00 BST
 permissions:
   id-token: write
 jobs:
@@ -21,6 +21,9 @@ jobs:
         run: ./scripts/appgateway/auto-start-stop.sh stop
         env:
           DEV_ENV: ${{ secrets.DEV_ENV }}
+
+      - name: Output log file
+        run: ./scripts/common/log-output.sh
 
       - name: Wait for App Gateways to stop
         run: sleep 300

--- a/.github/workflows/appgateway-auto-start.yaml
+++ b/.github/workflows/appgateway-auto-start.yaml
@@ -22,6 +22,9 @@ jobs:
         env:
           DEV_ENV: ${{ secrets.DEV_ENV }}
 
+      - name: Output log file
+        run: ./scripts/common/log-output.sh
+
       - name: Wait for App Gateways to start
         run: sleep 300
         

--- a/scripts/aks/auto-start-stop.sh
+++ b/scripts/aks/auto-start-stop.sh
@@ -20,10 +20,21 @@ jq -c '.[]' <<< $SUBSCRIPTIONS | while read subscription; do
   jq -c '.[]' <<< $CLUSTERS | while read cluster; do
     get_cluster_details
     cluster_env=$(echo $CLUSTER_NAME | cut -d'-' -f2)
-    cluster_env=${cluster_env/#sbox/Sandbox}
-    cluster_env=${cluster_env/stg/Staging}
+
+    if [[  $cluster_env == "sbox" ]]; then
+      cluster_env=${cluster_env/#sbox/Sandbox}
+    elif [[ $cluster_env == "ptlsbox" ]]; then
+      cluster_env=${cluster_env/ptlsbox/Sandbox}
+    elif [[ $cluster_env == "stg" ]]; then
+      cluster_env=${cluster_env/stg/Staging}
+    fi
+
     cluster_business_area=$(echo $CLUSTER_NAME | cut -d'-' -f1)
     cluster_business_area=${cluster_business_area/ss/cross-cutting}
+
+    log "====================================================="
+    log "Processing Cluster: $CLUSTER_NAME"
+    log "====================================================="
 
     log "checking skip logic for cluster_env: $cluster_env, cluster_business_area: $cluster_business_area, mode: $MODE"
     SKIP=$(should_skip_start_stop $cluster_env $cluster_business_area $MODE)

--- a/scripts/appgateway/auto-start-stop.sh
+++ b/scripts/appgateway/auto-start-stop.sh
@@ -34,8 +34,19 @@ jq -c '.[]' <<< $SUBSCRIPTIONS | while read subscription; do
         get_application_gateways_details
 
         # Set variables based on inputs which are used to decide when to SKIP an environment
-        application_gateway_env=${ENVIRONMENT/stg/Staging}
+        if [[  $ENVIRONMENT == "stg" ]]; then
+            application_gateway_env=${ENVIRONMENT/stg/Staging}
+        elif [[ $ENVIRONMENT == "sbox" ]]; then
+            application_gateway_env=${ENVIRONMENT/sbox/Sandbox}
+        else
+            application_gateway_env=$ENVIRONMENT
+        fi
+
         application_gateway_business_area=$BUSINESS_AREA
+        gatewayname=$APPLICATION_GATEWAY_NAME
+        log "====================================================="
+        log "Processing gateway: $gatewayname"
+        log "====================================================="
 
         # SKIP variable updated based on the output of the `should_skip_start_stop` function which calculates its value
         # based on the issues_list.json file which contains user requests to keep environments online after normal hours

--- a/scripts/common/common-functions.sh
+++ b/scripts/common/common-functions.sh
@@ -112,6 +112,10 @@ function should_skip_start_stop () {
   env=$1
   business_area=$2
   mode=$3
+  log "Checking function input vars"
+  log "env set to $env"
+  log "business_area set to $business_area"
+  log "mode set to $mode"
   # If its not onDemand we don't need to check the file issues_list.json for startup
   if [[ $STARTUP_MODE != "onDemand" && $mode == "start" ]]; then
     echo "false"


### PR DESCRIPTION
### Jira link (if applicable)
DTSPO-18502


### Change description ###
Following a number of tickets being raised, there was been an investigation into the skip logic within this repo. This PR addresses the following issues.

- Adds a second run at 23:00 to work with the already existing "stay on late" logic. This now matches the AKS clusters.
- Adds logging functionality to AppGateway workflow to aid with future troubleshooting.
- Conditional logic to set appropriate cluster_env variable, which now also supports ptlsbox, where it didn't before.
- Conditional logic to set appropriate application_gateway_env variable based on provided environment.
- Adds some initial logging to populate the log file, to aid future troubleshooting. This will expand over time. 

All of the above changes have been tested in the dev repo on the development branch - [HERE](https://github.com/hmcts/auto-shutdown-dev/tree/development)
