### PR TITLE
updating status check to match stop script

### DIFF
--- a/scripts/appgateway/appgw_status.sh
+++ b/scripts/appgateway/appgw_status.sh
@@ -34,10 +34,17 @@ jq -c '.[]' <<< $SUBSCRIPTIONS | while read subscription; do
     do
         # Function that returns the Resource Group, Id and Name of the Application Gateway and its current state as variables
         get_application_gateways_details
-
+        
         # Set variables based on inputs which are used to decide when to SKIP an environment
-        application_gateway_env=${ENVIRONMENT/stg/Staging}
-        application_gateway_business_area=${BUSINESS_AREA/ss/cross-cutting}
+        if [[  $ENVIRONMENT == "stg" ]]; then
+            application_gateway_env=${ENVIRONMENT/stg/Staging}
+        elif [[ $ENVIRONMENT == "sbox" ]]; then
+            application_gateway_env=${ENVIRONMENT/sbox/Sandbox}
+        else
+            application_gateway_env=$ENVIRONMENT
+        fi
+
+        application_gateway_business_area=$BUSINESS_AREA
 
         # SKIP variable updated based on the output of the `should_skip_start_stop` function which calculates its value
         # based on the issues_list.json file which contains user requests to keep environments online after normal hours


### PR DESCRIPTION
The App Gateway status check was showing incorrect results following a [previous change ](https://github.com/hmcts/auto-shutdown/pull/680/files#diff-0797fff783f4accfc2e2b6fa56ced323cc4bc2a825604d6d4fcd10937c796a3dR37) made to the auto start / stop script.

This PR updates the status check to match the previous change and should resolve the false positive notification.