### PR TITLE
DTSPO-18734: Allow replicas to be started first

### DIFF
--- a/scripts/flexible-server/common-functions.sh
+++ b/scripts/flexible-server/common-functions.sh
@@ -5,7 +5,7 @@ function get_subscription_flexible_sql_servers() {
   SUBSCRIPTION_ID=$(jq -r '.id' <<< $subscription)
   SUBSCRIPTION_NAME=$(jq -r '.name' <<< $subscription)
   az account set -s $SUBSCRIPTION_ID
-  FLEXIBLE_SERVERS=$(az resource list --resource-type Microsoft.DBforPostgreSQL/flexibleServers --query "[?tags.autoShutdown == 'true']" -o json)
+  FLEXIBLE_SERVERS=$(az resource list --resource-type Microsoft.DBforPostgreSQL/flexibleServers --query "reverse(sort_by([?tags.autoShutdown == 'true'], &to_string(contains(id, 'replica'))))" -o json)
 }
 
 # Function that accepts the flexible sql server json as input and sets variables for later use to stop or start the flexible sql server


### PR DESCRIPTION
[DTSPO-18734](https://tools.hmcts.net/jira/browse/DTSPO-18734)

Teams have a need for replica DB to be `up` before their main DBs. This change is updating the order that things get pulled back from azure in, such that anything with `replica` is returned at the top of the list, hence being started before all other flex servers

i tested this locally and it returns replica dbs first now, this is because of using `reverse`
