### PR TITLE
DTSPO-18841 - az graph for Flexible servers.

### DIFF
--- a/scripts/flexible-server/auto-start-stop.sh
+++ b/scripts/flexible-server/auto-start-stop.sh
@@ -16,6 +16,10 @@ if [[ "$MODE" != "start" && "$MODE" != "stop" ]]; then
     exit 1
 fi
 
+log "Running az graph query..."
+FLEXIBLE_SERVERS=$(az graph query -q "resources | where type =~ 'microsoft.dbforpostgresql/flexibleservers' | where tags.autoShutdown == 'true' | project name, resourceGroup, subscriptionId, ['tags'], properties.state, ['id']" --first 1000 -o json)
+log "az graph query complete"
+
 # For each App Gateway found in the function `get_subscription_flexible_sql_servers` start another loop
 jq -c '.data[]' <<<$FLEXIBLE_SERVERS | while read flexibleserver; do
 

--- a/scripts/flexible-server/auto-start-stop.sh
+++ b/scripts/flexible-server/auto-start-stop.sh
@@ -16,53 +16,41 @@ if [[ "$MODE" != "start" && "$MODE" != "stop" ]]; then
     exit 1
 fi
 
-# Find all subscriptions that are available to the credential used and saved to SUBSCRIPTIONS variable
-SUBSCRIPTIONS=$(az account list -o json)
+# For each App Gateway found in the function `get_subscription_flexible_sql_servers` start another loop
+jq -c '.[]' <<<$FLEXIBLE_SERVERS | while read flexibleserver; do
 
-# For each subscription found, start the loop
-jq -c '.[]' <<< $SUBSCRIPTIONS | while read subscription; do
+    # Function that returns the Resource Group, Id and Name of the Flexible SQL Server and its current state as variables
+    get_flexible_sql_server_details
 
-    # Function that returns the Subscription Id and Name as variables, sets the subscription as
-    # the default then returns a json formatted variable of available App Gateways with an autoshutdown tag
-    get_subscription_flexible_sql_servers
-    echo "Scanning $SUBSCRIPTION_NAME..."
+    # Set variables based on inputs which are used to decide when to SKIP an environment
+    if [[ $ENVIRONMENT == "stg" ]]; then
+        flexible_server_env=${ENVIRONMENT/stg/Staging}
+    elif [[ $ENVIRONMENT == "sbox" ]]; then
+        flexible_server_env=${ENVIRONMENT/sbox/Sandbox}
+    else
+        flexible_server_env=$ENVIRONMENT
+    fi
 
-    # For each App Gateway found in the function `get_subscription_flexible_sql_servers` start another loop
-    jq -c '.[]' <<< $FLEXIBLE_SERVERS | while read flexibleserver; do
+    flexible_server_business_area=$BUSINESS_AREA
 
-        # Function that returns the Resource Group, Id and Name of the Flexible SQL Server and its current state as variables
-        get_flexible_sql_server_details
+    log "====================================================="
+    log "Processing Flexible Server: $SERVER_NAME"
+    log "====================================================="
 
-        # Set variables based on inputs which are used to decide when to SKIP an environment
-        if [[  $ENVIRONMENT == "stg" ]]; then
-            flexible_server_env=${ENVIRONMENT/stg/Staging}
-        elif [[ $ENVIRONMENT == "sbox" ]]; then
-            flexible_server_env=${ENVIRONMENT/sbox/Sandbox}
+    # SKIP variable updated based on the output of the `should_skip_start_stop` function which calculates its value
+    # based on the issues_list.json file which contains user requests to keep environments online after normal hours
+    SKIP=$(should_skip_start_stop $flexible_server_env $flexible_server_business_area $MODE)
+
+    # If SKIP is false then we progress with the action (stop/start) for the particular App Gateway in this loop run, if not skip and print message to the logs
+    if [[ $SKIP == "false" ]]; then
+        if [[ $DEV_ENV != "true" ]]; then
+            flexible_server_state_messages
+            az postgres flexible-server $MODE --resource-group $RESOURCE_GROUP --name $SERVER_NAME --subscription $SUBSCRIPTION --no-wait || echo Ignoring any errors while $MODE operation on sql server
         else
-            flexible_server_env=$ENVIRONMENT
+            ts_echo_color BLUE "Development Env: simulating state commands only."
+            flexible_server_state_messages
         fi
-
-        flexible_server_business_area=$BUSINESS_AREA
-
-        log "====================================================="
-        log "Processing Flexible Server: $SERVER_NAME"
-        log "====================================================="
-
-        # SKIP variable updated based on the output of the `should_skip_start_stop` function which calculates its value
-        # based on the issues_list.json file which contains user requests to keep environments online after normal hours
-        SKIP=$(should_skip_start_stop $flexible_server_env $flexible_server_business_area $MODE)
-
-        # If SKIP is false then we progress with the action (stop/start) for the particular App Gateway in this loop run, if not skip and print message to the logs
-        if [[ $SKIP == "false" ]]; then
-            if [[ $DEV_ENV != "true" ]]; then
-                flexible_server_state_messages
-                az postgres flexible-server $MODE --resource-group $RESOURCE_GROUP --name $SERVER_NAME --no-wait || echo Ignoring any errors while $MODE operation on sql server
-            else
-                ts_echo_color BLUE "Development Env: simulating state commands only."
-                flexible_server_state_messages
-            fi
-        else
-            ts_echo_color AMBER "SQL server $SERVER_NAME (rg:$RESOURCE_GROUP) has been skipped from today's $MODE operation schedule"
-        fi
-    done
+    else
+        ts_echo_color AMBER "SQL server $SERVER_NAME (rg:$RESOURCE_GROUP) has been skipped from today's $MODE operation schedule"
+    fi
 done

--- a/scripts/flexible-server/auto-start-stop.sh
+++ b/scripts/flexible-server/auto-start-stop.sh
@@ -17,7 +17,7 @@ if [[ "$MODE" != "start" && "$MODE" != "stop" ]]; then
 fi
 
 # For each App Gateway found in the function `get_subscription_flexible_sql_servers` start another loop
-jq -c '.[]' <<<$FLEXIBLE_SERVERS | while read flexibleserver; do
+jq -c '.data[]' <<<$FLEXIBLE_SERVERS | while read flexibleserver; do
 
     # Function that returns the Resource Group, Id and Name of the Flexible SQL Server and its current state as variables
     get_flexible_sql_server_details

--- a/scripts/flexible-server/common-functions.sh
+++ b/scripts/flexible-server/common-functions.sh
@@ -3,14 +3,21 @@
 # Function that accepts the flexible sql server json as input and sets variables for later use to stop or start the flexible sql server
 function get_flexible_sql_server_details() {
   RESOURCE_GROUP=$(jq -r '.resourceGroup' <<< $flexibleserver)
+  log "$RESOURCE_GROUP"
   SERVER_ID=$(jq -r '.id' <<< $flexibleserver)
+  log "$SERVER_ID"
   SERVER_NAME=$(jq -r '.name' <<< $flexibleserver)
+  log "$SERVER_NAME"
   ENVIRONMENT=$(echo $SERVER_NAME | rev | cut -d'-' -f 1 | rev )
+  log "$ENVIRONMENT"
   BUSINESS_AREA=$( jq -r 'if (.tags.businessArea | ascii_downcase) == "ss" then "cross-cutting" else .tags.businessArea | ascii_downcase end' <<< $flexibleserver)
+  log "$BUSINESS_AREA"
   STARTUP_MODE=$(jq -r '.tags.startupMode' <<< $flexibleserver)
+  log "$STARTUP_MODE"
   SERVER_STATE=$(jq -r '.properties_state' <<< $flexibleserver)
+  log "$SERVER_STATE"
   SUBSCRIPTION=$(jq -r '.subscriptionId' <<< $flexibleserver)
-
+  log "$SUBSCRIPTION"
 }
 
 function flexible_server_state_messages() {

--- a/scripts/flexible-server/common-functions.sh
+++ b/scripts/flexible-server/common-functions.sh
@@ -1,13 +1,5 @@
 #!/bin/bash
 
-# Function that uses the subscription input to get set variables for later use and gather all flexible sql servers within the subscription for shutdown
-function get_subscription_flexible_sql_servers() {
-  SUBSCRIPTION_ID=$(jq -r '.id' <<< $subscription)
-  SUBSCRIPTION_NAME=$(jq -r '.name' <<< $subscription)
-  az account set -s $SUBSCRIPTION_ID
-  FLEXIBLE_SERVERS=$(az resource list --resource-type Microsoft.DBforPostgreSQL/flexibleServers --query "reverse(sort_by([?tags.autoShutdown == 'true'], &to_string(contains(id, 'replica'))))" -o json)
-}
-
 # Function that accepts the flexible sql server json as input and sets variables for later use to stop or start the flexible sql server
 function get_flexible_sql_server_details() {
   RESOURCE_GROUP=$(jq -r '.resourceGroup' <<< $flexibleserver)
@@ -16,7 +8,8 @@ function get_flexible_sql_server_details() {
   ENVIRONMENT=$(echo $SERVER_NAME | rev | cut -d'-' -f 1 | rev )
   BUSINESS_AREA=$( jq -r 'if (.tags.businessArea | ascii_downcase) == "ss" then "cross-cutting" else .tags.businessArea | ascii_downcase end' <<< $flexibleserver)
   STARTUP_MODE=$(jq -r '.tags.startupMode' <<< $flexibleserver)
-  SERVER_STATE=$(az postgres flexible-server show --ids $SERVER_ID --query "state" | jq -r)
+  SERVER_STATE=$(jq -r '.properties_state' <<< $flexibleserver)
+  SUBSCRIPTION=$(jq -r '.subscriptionId' <<< $flexibleserver)
 
 }
 


### PR DESCRIPTION
### Jira link
[DTSPO-18841](https://tools.hmcts.net/jira/browse/DTSPO-18841)

### Change description

Using 'az graph' instead of 'az resource' to improve script efficiency as graph works across all subscriptions we won't need to loop through all subscriptions individually.

During testing this has cut the run time down from +42 minutes to just over 1 minute.

Following successful testing within this repo, I will roll this out to the remaining scripts to maintain consistency.

### Testing done
- Tested in auto-shutdown-dev repo

Before
![image](https://github.com/user-attachments/assets/3bb18390-bf0f-4649-a189-9f7ac3f66c43)

After
![Screenshot 2024-09-16 at 15 30 36](https://github.com/user-attachments/assets/5848761b-3efa-4cfb-b029-e07a14020324)
