### PR TITLE
DTSPO-19088 - Correcting AKS Cluster status script

### DIFF
--- a/.github/workflows/aks-auto-shutdown.yaml
+++ b/.github/workflows/aks-auto-shutdown.yaml
@@ -51,6 +51,12 @@ jobs:
         env:
           DEV_ENV: ${{ env.DEV_ENV }}
 
+      #Production is referenced here to include the PTL clusters, these are the only production clusters that will be impacted.
+      - name: PROD - AKS Auto Stop
+        run: ./scripts/aks/auto-start-stop.sh stop production
+        env:
+          DEV_ENV: ${{ env.DEV_ENV }}
+
       - name: Untagged - AKS Auto Stop
         run: ./scripts/aks/auto-start-stop.sh stop untagged
         env:

--- a/.github/workflows/aks-auto-start.yaml
+++ b/.github/workflows/aks-auto-start.yaml
@@ -51,6 +51,12 @@ jobs:
         env:
           DEV_ENV: ${{ env.DEV_ENV }}
 
+      #Production is referenced here to include the PTL clusters, these are the only production clusters that will be impacted.
+      - name: PROD - AKS Auto Start
+        run: ./scripts/aks/auto-start-stop.sh start production
+        env:
+          DEV_ENV: ${{ env.DEV_ENV }}
+
       - name: Untagged - AKS Auto Start
         run: ./scripts/aks/auto-start-stop.sh start untagged
         env:

--- a/scripts/aks/auto-shutdown-status.sh
+++ b/scripts/aks/auto-shutdown-status.sh
@@ -1,8 +1,6 @@
 #!/usr/bin/env bash
 
 shopt -s nocasematch
-AMBER='\033[1;33m'
-GREEN='\033[0;32m'
 source scripts/aks/common-functions.sh
 source scripts/common/common-functions.sh
 
@@ -46,7 +44,7 @@ jq -c '.data[]' <<<$CLUSTERS | while read cluster; do
 
     # Setup message output templates for later use
     logMessage="SKIP was $SKIP on Cluster: $CLUSTER_NAME in Subscription: $SUBSCRIPTION  ResourceGroup: $RESOURCE_GROUP is in $CLUSTER_STATUS state after $MODE action"
-    slackMessage="SKIP was $SKIP on Cluster: *$CLUSTER_NAME* in Subscription: *$SUBSCRIPTION* is in *$CLUSTER_STATUS* state after *$MODE* action"
+    slackMessage="Cluster: *$CLUSTER_NAME* in Subscription: *$SUBSCRIPTION* is in *$CLUSTER_STATUS* state after *$MODE* action"
 
     # If SKIP is false then we progress with the status check for the particular AKS Cluster in this loop run, if SKIP is true then do nothing
     if [[ $SKIP == "false" ]]; then

--- a/scripts/aks/auto-shutdown-status.sh
+++ b/scripts/aks/auto-shutdown-status.sh
@@ -1,22 +1,19 @@
 #!/usr/bin/env bash
 
 shopt -s nocasematch
+# Source shared function scripts
 source scripts/aks/common-functions.sh
 source scripts/common/common-functions.sh
 
 MODE=${1:-start}
 SKIP="false"
 
-if [[ "$MODE" != "start" && "$MODE" != "stop" ]]; then
-  echo "Invalid MODE. Please use 'start' or 'stop'."
-  exit 1
-fi
-
 CLUSTERS=$(get_clusters)
 clusters_count=$(jq -c -r '.count' <<<$CLUSTERS)
 ts_echo "$clusters_count AKS Clusters found"
 
 jq -c '.data[]' <<<$CLUSTERS | while read cluster; do
+# Function that returns the Resource Group, Id and Name of the AKS Cluster and its current state as variables
   get_cluster_details
   cluster_env=$(echo $CLUSTER_NAME | cut -d'-' -f2)
 

--- a/scripts/aks/auto-shutdown-status.sh
+++ b/scripts/aks/auto-shutdown-status.sh
@@ -14,8 +14,7 @@ fi
 
 CLUSTERS=$(get_clusters)
 clusters_count=$(jq -c -r '.count' <<<$CLUSTERS)
-log "$clusters_count AKS Clusters found"
-log "----------------------------------------------"
+ts_echo "$clusters_count AKS Clusters found"
 
 jq -c '.data[]' <<<$CLUSTERS | while read cluster; do
   get_cluster_details


### PR DESCRIPTION
### Jira link
[DTSPO-19088](https://tools.hmcts.net/jira/browse/DTSPO-19088)

### Change description

- Adding production flag to include PTL clusters (there were previously included in the old scripts)
- Correcting status script to avoid sending errors where clusters are expected to not be shutdown.

### Testing done

Tested in development environment
To be monitored
