### PR TITLE
Update to fix json file storage

### DIFF
--- a/scripts/common/common-functions.sh
+++ b/scripts/common/common-functions.sh
@@ -69,6 +69,9 @@ function add_to_json() {
   local mode="$5"
   # Send to json file dependent on resource type
   local pathToJson="status/${resourceType}_status_updates_${mode}.json"
+  
+  # Create dir if not exists
+  mkdir -p status
 
   # Create JSON file if it does not exist or is empty
   if [[ ! -f "$pathToJson" || ! -s "$pathToJson" ]]; then


### PR DESCRIPTION
This was working but missed the change that required these files to go into a new dir, had this created locally so it worked but when running remotely the `status` dir was missing, causing:

````scripts/common/common-functions.sh: line 75: status/flexible-server_status_updates_stop.json: No such file or directory
jq: error: Could not open file status/flexible-server_status_updates_stop.json: No such file or directory
JSON file updated successfully.```

This change adds the dir so the file can be built correctly