### PR TITLE
Update auto-stop-status-check.yaml

### DIFF
--- a/.github/workflows/auto-stop-status-check.yaml
+++ b/.github/workflows/auto-stop-status-check.yaml
@@ -3,6 +3,8 @@ on:
   workflow_dispatch:
   schedule:
     - cron: "30 19,22 * * *" # Every day at 20:30 and 23:30 BST
+env:
+  GH_TOKEN: ${{ secrets.PLATFORM_USER_TOKEN }}
 permissions:
   id-token: write
 jobs:
@@ -11,6 +13,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: '0'
+          token: ${{ env.GH_TOKEN }}
 
       - name: "Az CLI login"
         uses: azure/login@v2


### PR DESCRIPTION
This file works https://github.com/hmcts/auto-shutdown/blob/master/.github/workflows/housekeeping_aks_issuejson.yaml with the exact same account , but this run for some reason does not have access to push to a branch...

This is the only difference I can see between the two that's common to the goal of pushing a change

