### PR TITLE
DTSPO-18652 - Adding weekend logic fix

### DIFF
--- a/scripts/aks/send-slack-message.sh
+++ b/scripts/aks/send-slack-message.sh
@@ -4,7 +4,7 @@ source scripts/common/common-functions.sh
 # Define Bash variables
 request_url_link="*<$REQUEST_URL|$CHANGE_JIRA_ID>*"
 request_title_link="*<$REQUEST_URL|$ISSUE_TITLE>*"
-current_date=$(get_current_date)
+current_date=$(get_current_date_time)
 environment_field=$(echo "$ENVIRONMENT" | sed 's/\[//; s/\]//; s/"//g')
 slack_username=$(get_slack_displayname_from_github_username $REQUESTER)
 slack_reviewer=$(get_slack_displayname_from_github_username $REVIEWER)


### PR DESCRIPTION
### Jira link
[DTSPO-18652](https://tools.hmcts.net/jira/browse/DTSPO-18652)

### Change description

- Creating new get_current_date_time function for slack message process to allow the use of get_current_date in weekend logic.
- Expanding is_late_night_run() function condition to include early hours of the. morning as "late night".
- Reducing unnecessary logging making troubleshooting more difficult.
- Adding break clause to while look in is_weekend_in_range() (once a weekend has been found, there is no need to continue the loop).
- Moving late night and weekend day function calls to outside of the read issue loop as this only needs to occur once.

### Testing done

Tested multiple scenarios in the dev environment.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ x ] commit messages are meaningful and follow good commit message guidelines
- [ x ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
