### PR TITLE
allowing auto-shutdown to work in production enviornment where config…

### DIFF
--- a/.github/workflows/vm-auto-shutdown.yaml
+++ b/.github/workflows/vm-auto-shutdown.yaml
@@ -19,6 +19,12 @@ jobs:
           client-id: 2b6fa9d7-7dba-4600-a58a-5e25554997aa # DTS AKS Auto-Shutdown
           tenant-id: 531ff96d-0ae9-462a-8d2d-bec7c0b42082 # HMCTS.NET
           allow-no-subscriptions: true
+      #Production is included here to allow for select resoucres to be stopped. Only resoucres tagged with autoShutdown: true will be stopped.
+      - name: Production - VM Auto Stop
+        run: ./scripts/vm/auto-start-stop.sh deallocate production
+        env:
+          DEV_ENV: ${{ env.DEV_ENV }}
+
       - name: Staging - VM Auto Stop
         run: ./scripts/vm/auto-start-stop.sh deallocate staging
         env:

--- a/.github/workflows/vm-auto-start.yaml
+++ b/.github/workflows/vm-auto-start.yaml
@@ -19,6 +19,7 @@ jobs:
           client-id: 2b6fa9d7-7dba-4600-a58a-5e25554997aa # DTS AKS Auto-Shutdown
           tenant-id: 531ff96d-0ae9-462a-8d2d-bec7c0b42082 # HMCTS.NET
           allow-no-subscriptions: true
+      #Production is included here to allow for select resoucres to be started. Only resoucres tagged with autoShutdown: true will be started.
       - name: Production - VM Auto Start 
         run: ./scripts/vm/auto-start-stop.sh start production
         env:

--- a/.github/workflows/vm-auto-start.yaml
+++ b/.github/workflows/vm-auto-start.yaml
@@ -19,6 +19,11 @@ jobs:
           client-id: 2b6fa9d7-7dba-4600-a58a-5e25554997aa # DTS AKS Auto-Shutdown
           tenant-id: 531ff96d-0ae9-462a-8d2d-bec7c0b42082 # HMCTS.NET
           allow-no-subscriptions: true
+      - name: Production - VM Auto Start 
+        run: ./scripts/vm/auto-start-stop.sh start production
+        env:
+          DEV_ENV: ${{ env.DEV_ENV }}
+
       - name: Staging - VM Auto Start
         run: ./scripts/vm/auto-start-stop.sh start staging
         env:


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DTSPO-22674

### Change description

Enabling scripts to check for resources setup for auto-shutdown within production environments.

**No production resources without the autoShutdown tag set to true will be affected.**

Specifically, this is to allow the auto shutdown and start of hmcts-hub-prod-int-palo-ansible as per https://tools.hmcts.net/jira/browse/DTSPO-22674

### Testing done

Tested in dev

See screenshot confirming query will only catch the intended production resource.

![Screenshot 2024-12-19 at 16 03 22](https://github.com/user-attachments/assets/6fce267c-e35f-4410-8855-8e8568c626e6)


### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
