### PR TITLE
DTSPO-23335 - Modify Graph query to target specific fields

### DIFF
--- a/scripts/aks/common-functions.sh
+++ b/scripts/aks/common-functions.sh
@@ -43,7 +43,7 @@ function get_cluster_details() {
     RESOURCE_GROUP=$(jq -r '.resourceGroup' <<<$cluster)
     CLUSTER_NAME=$(jq -r '.name' <<<$cluster)
     STARTUP_MODE=$(jq -r '.tags.startupMode' <<<$cluster)
-    CLUSTER_STATUS=$(jq -r '.properties.powerState.code' <<<$cluster)
+    CLUSTER_STATUS=$(jq -r '.properties_powerState_code' <<<$cluster)
     SUBSCRIPTION=$(jq -r '.subscriptionId' <<<$cluster)
 }
 

--- a/scripts/aks/common-functions.sh
+++ b/scripts/aks/common-functions.sh
@@ -33,7 +33,7 @@ function get_clusters() {
     | where tags.autoShutdown == 'true'
     $env_selector
     $area_selector
-    | project name, resourceGroup, subscriptionId, ['tags'], properties, ['id']
+    | project name, resourceGroup, subscriptionId, ['tags'], properties.powerState.code, ['id']
     " --first 1000 -o json
 
     log "az graph query complete"

--- a/scripts/vm/common-functions.sh
+++ b/scripts/vm/common-functions.sh
@@ -25,7 +25,7 @@ function get_vms() {
     | where tags.autoShutdown == 'true'
     $env_selector
     $area_selector
-    | project name, resourceGroup, subscriptionId, ['tags'], properties.extended.instanceView.powerState.code, ['id']
+    | project name, resourceGroup, subscriptionId, ['tags'], properties.extended.instanceView.powerState.displayStatus, ['id']
     " --first 1000 -o json
 
     log "az graph query complete"
@@ -38,7 +38,7 @@ function get_vm_details() {
   ENVIRONMENT=$(jq -r '.tags.environment // .tags.Environment // "tag_not_set"' <<< "$vm")
   BUSINESS_AREA=$(jq -r 'if (.tags.businessArea // .tags.BusinessArea // "tag_not_set" | ascii_downcase) == "ss" then "cross-cutting" else (.tags.businessArea // .tags.BusinessArea // "tag_not_set" | ascii_downcase) end' <<< $vm)
   STARTUP_MODE=$(jq -r '.tags.startupMode // "false"' <<< $vm)
-  VM_STATE=$(jq -r '.properties_extended_instanceView_powerState_codee' <<< $vm)
+  VM_STATE=$(jq -r '.properties_extended_instanceView_powerState_displayStatus' <<< $vm)
   SUBSCRIPTION=$(jq -r '.subscriptionId' <<<$vm)
   VM_ID="/subscriptions/$SUBSCRIPTION/resourceGroups/$RESOURCE_GROUP/providers/Microsoft.Compute/virtualMachines/$VM_NAME"
 }

--- a/scripts/vm/common-functions.sh
+++ b/scripts/vm/common-functions.sh
@@ -25,7 +25,7 @@ function get_vms() {
     | where tags.autoShutdown == 'true'
     $env_selector
     $area_selector
-    | project name, resourceGroup, subscriptionId, ['tags'], properties, ['id']
+    | project name, resourceGroup, subscriptionId, ['tags'], properties.extended.instanceView.powerState.code, ['id']
     " --first 1000 -o json
 
     log "az graph query complete"
@@ -38,7 +38,7 @@ function get_vm_details() {
   ENVIRONMENT=$(jq -r '.tags.environment // .tags.Environment // "tag_not_set"' <<< "$vm")
   BUSINESS_AREA=$(jq -r 'if (.tags.businessArea // .tags.BusinessArea // "tag_not_set" | ascii_downcase) == "ss" then "cross-cutting" else (.tags.businessArea // .tags.BusinessArea // "tag_not_set" | ascii_downcase) end' <<< $vm)
   STARTUP_MODE=$(jq -r '.tags.startupMode // "false"' <<< $vm)
-  VM_STATE=$(jq -r '.properties.extended.instanceView.powerState.code' <<< $vm)
+  VM_STATE=$(jq -r '.properties_extended_instanceView_powerState_codee' <<< $vm)
   SUBSCRIPTION=$(jq -r '.subscriptionId' <<<$vm)
   VM_ID="/subscriptions/$SUBSCRIPTION/resourceGroups/$RESOURCE_GROUP/providers/Microsoft.Compute/virtualMachines/$VM_NAME"
 }

--- a/scripts/vm/vmstatus.sh
+++ b/scripts/vm/vmstatus.sh
@@ -55,14 +55,14 @@ jq -c '.data[]' <<<$VMS | while read vm; do
 		#    - If MODE = deallocate then a running VM is incorrect and we should notify
 		#    - If neither Running or Stopped is found then something else is going on and we should notify
             case "$VM_STATE" in
-                *"PowerState/running"*)
+                *"VM running"*)
                     ts_echo_color $( [[ $MODE == "start" ]] && echo GREEN || echo RED ) "$logMessage"
                     if [[ $MODE == "deallocate" ]]; then
                         auto_shutdown_notification ":red_circle: $slackMessage"
                         add_to_json "$VM_ID" "$VM_NAME" "$slackMessage" "vm" "$MODE"
                     fi
                     ;;
-                *"PowerState/deallocated"*)
+                *"VM deallocated"*)
                     ts_echo_color $( [[ $MODE == "start" ]] && echo RED || echo GREEN ) "$logMessage"
                     if [[ $MODE == "start" ]]; then
                         auto_shutdown_notification ":red_circle: $slackMessage"


### PR DESCRIPTION
### Jira link

[DTSPO-23335](https://tools.hmcts.net/jira/browse/DTSPO-23335)

### Change description

The result of the status check for the VM 'CTS' was appearing with empty values in the auto-shutdown-status channel. This created an unhelpful status message and didn't inspire confidence for the rest of the checks. See below

![image](https://github.com/user-attachments/assets/79321eeb-2fde-4e37-ba09-d6c10fc200bb)

After investigation, it was found that the existing MS Graph query was retrieving public key information by default. In the case of this specific VM, the key data contained characters that invalidated the json payload. Due to this, the scripts were unable to retrieve information such as resource group, name, environment, business area, start up mode or VM state.  This also explains why this was occurring for this VM, and not others.

This PR makes the Graph query more specific to only retrieve the properties that we require, which does not include the public key information.


### Testing done

Tested in dev environment and via MS Graph in Azure portal.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
