### PR TITLE
Adding 23:00 run to more resources

### DIFF
--- a/.github/workflows/flexibleserver-auto-shutdown.yaml
+++ b/.github/workflows/flexibleserver-auto-shutdown.yaml
@@ -2,7 +2,7 @@ name: flexible-server-auto-shutdown
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 20 * * *" # Every day at 8pm BST
+    - cron: "0 20,23 * * *" # Every day at 20:00 and 23:00 BST
 env:
   DEV_ENV: ${{ secrets.DEV_ENV }}
 permissions:

--- a/.github/workflows/sqlmi-auto-shutdown.yaml
+++ b/.github/workflows/sqlmi-auto-shutdown.yaml
@@ -2,7 +2,7 @@ name: sql-managed-instance-auto-shutdown
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 20 * * *" # Every day at 8pm BST
+    - cron: "0 20,23 * * *" # Every day at 20:00 and 23:00 BST
 env:
   DEV_ENV: ${{ secrets.DEV_ENV }}
 permissions:

--- a/.github/workflows/storage-sftp-auto-disable.yaml
+++ b/.github/workflows/storage-sftp-auto-disable.yaml
@@ -2,7 +2,7 @@ name: storage-sftp-auto-disable
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 20 * * *" # Every day at 8pm BST
+    - cron: "0 20,23 * * *" # Every day at 20:00 and 23:00 BST
 env:
   DEV_ENV: ${{ secrets.DEV_ENV }}
 permissions:


### PR DESCRIPTION
### Jira link

N/A

### Change description

Whole investigating a lot of unexpected output in the auto-shutdown-status channel, I noticed that some resources do not have a scheduled 23:00 run. 

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
