### PR TITLE
DTSPO-23913 - setting flexserver to start before VM's

### DIFF
--- a/.github/workflows/flexibleserver-auto-start.yaml
+++ b/.github/workflows/flexibleserver-auto-start.yaml
@@ -2,7 +2,7 @@ name: flexible-server-auto-start
 on:
   workflow_dispatch:
   schedule:
-    - cron: '30 6 * * 1-5' # Every weekday at 6:30am BST
+    - cron: '15 6 * * 1-5' # Every weekday at 6:15am BST
 env:
   DEV_ENV: ${{ secrets.DEV_ENV }}
 permissions:


### PR DESCRIPTION
### Jira link

DTSPO-23913

### Change description

Setting flexserver to start before VM's as services trying to connect to DB's at startup may be left in a failed state if connections fail.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
