### PR TITLE
Set Elasticsearch pipeline to always start

### DIFF
--- a/azure-pipeline-start-elasticsearch.yml
+++ b/azure-pipeline-start-elasticsearch.yml
@@ -6,6 +6,7 @@ schedules:
     branches:
       include:
         - master
+    always: true
 
 pool:
   name: 'hmcts-cftptl-agent-pool'


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/DTSPO-24698

### Change description
- Pointed out in the above ticket that Elasticsearch failed to start yesterday morning and was not retried until near 4pm. (Should be every one hour)
- Adding `always: true` to pipeline to make sure it always runs on cron schedule
<!--
Provide a description of what change you are proposing.
A short summary here and then you can add comments in your pull request explaining your change to others.
-->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is not always complete, so a successful pull request build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
