### PR TITLE
Enable cron triggers for VM Scale Sets auto shutdown/startup workflows

### DIFF
--- a/.github/workflows/vmss-auto-shutdown.yaml
+++ b/.github/workflows/vmss-auto-shutdown.yaml
@@ -1,8 +1,8 @@
 name: vmss-auto-shutdown
 on:
   workflow_dispatch:
-#  schedule:
-#    - cron: "0 20,23 * * *" # Every day at 20:00 and 23:00 BST
+  schedule:
+    - cron: "0 20,23 * * *" # Every day at 20:00 and 23:00 BST
 env:
   DEV_ENV: ${{ secrets.DEV_ENV }}
 permissions:

--- a/.github/workflows/vmss-auto-start.yaml
+++ b/.github/workflows/vmss-auto-start.yaml
@@ -1,8 +1,8 @@
 name: vmss-auto-start
 on:
   workflow_dispatch:
-#  schedule:
-#    - cron: "30 6 * * 1-5" # Every weekday at 6:30am BST
+  schedule:
+    - cron: "30 6 * * 1-5" # Every weekday at 6:30am BST
 env:
   DEV_ENV: ${{ secrets.DEV_ENV }}
 permissions:


### PR DESCRIPTION
### Jira link

See [DTSPO-23901](https://tools.hmcts.net/jira/browse/DTSPO-23901)

### Change description

Enable cron triggers for VM Scale Sets auto shutdown/startup workflows. This is to be merged only after these new workflows has been end to end tested.

### Testing done

 - Unit testing has been done (manual). The VM Scale Sets auto-start-stop.sh has been manually tested.
 - End to end testing must be done before merging this PR.

### Checklist

- [X] commit messages are meaningful and follow good commit message guidelines
- [X] README and other documentation has been updated / added (if needed)
- [X] tests have been updated / new tests has been added (if needed)
- [X] (No) Does this PR introduce a breaking change
