### PR TITLE
Fix the auto startup/shutdown scripts for VM Scale Sets

### DIFF
--- a/scripts/vmss/manual-start-stop.sh
+++ b/scripts/vmss/manual-start-stop.sh
@@ -71,10 +71,7 @@ jq -c '.data[]' <<<$VMSS_LIST | while read vmss; do
     fi
 
     # Get VMSS power state after operation
-    RESULT=$(az graph query -q "resources 
-    | where ['name'] == '$VMSS_NAME' 
-    | project properties" -o json | jq -r '.data[0].properties.extended.instanceView.powerState.code')
-
-    ts_echo "VM Scale Set: $VMSS_NAME is in state: $RESULT"
+    new_state=$(get_vmss_by_id $VMSS_ID | jq -cr '.powerState | split("/")[1]')
+    ts_echo "VM Scale Set: $VMSS_NAME is in state: $new_state"
 
 done

--- a/scripts/vmss/vmss-status.sh
+++ b/scripts/vmss/vmss-status.sh
@@ -18,10 +18,10 @@ if [[ "$MODE" != "start" && "$MODE" != "deallocate" ]]; then
 	exit 1
 fi
 
-VMSS=$(get_vmss | jq '.data | map(.tags |= fromjson)')
+VMSS=$(get_vmss)
 
 # Iterate over each VMSS instance
-jq -c '.[]' <<<$VMSS | while read vmss; do
+jq -c '.data[]' <<<$VMSS | while read vmss; do
     # Retrieve details about the VMSS instance
     get_vmss_details
 


### PR DESCRIPTION
### Jira link

See [DTSPO-23901](https://tools.hmcts.net/jira/browse/DTSPO-23901)

### Change description

Bugfixes in the VM Scale Sets auto shutdown and startup, vmss status and manual start/stop scripts

### Testing done

Tested locally in a terminal, az commands echoed to the screen.

### Checklist

- [X] commit messages are meaningful and follow good commit message guidelines
- [X] README and other documentation has been updated / added (if needed)
- [X] tests have been updated / new tests has been added (if needed)
- [X] (No) Does this PR introduce a breaking change
