### PR TITLE
Add sleep to flex server auto start/stop

### DIFF
--- a/.github/workflows/flexibleserver-auto-shutdown.yaml
+++ b/.github/workflows/flexibleserver-auto-shutdown.yaml
@@ -20,38 +20,79 @@ jobs:
           tenant-id: 531ff96d-0ae9-462a-8d2d-bec7c0b42082 # HMCTS.NET
           allow-no-subscriptions: true
 
+      # PRIMARY
       - name: Staging - Postgres Flexible server Auto Stop
-        run: ./scripts/flexible-server/auto-start-stop.sh stop staging
+        run: ./scripts/flexible-server/auto-start-stop.sh stop staging '' primary
         env:
           DEV_ENV: ${{ env.DEV_ENV }}
 
       - name: Test - Postgres Flexible server Auto Stop
-        run: ./scripts/flexible-server/auto-start-stop.sh stop testing
+        run: ./scripts/flexible-server/auto-start-stop.sh stop testing '' primary
         env:
           DEV_ENV: ${{ env.DEV_ENV }}
 
       - name: Demo - Postgres Flexible server Auto Stop
-        run: ./scripts/flexible-server/auto-start-stop.sh stop demo
+        run: ./scripts/flexible-server/auto-start-stop.sh stop demo '' primary
         env:
           DEV_ENV: ${{ env.DEV_ENV }}
 
       - name: Development - Postgres Flexible server Auto Stop
-        run: ./scripts/flexible-server/auto-start-stop.sh stop development
+        run: ./scripts/flexible-server/auto-start-stop.sh stop development '' primary
         env:
           DEV_ENV: ${{ env.DEV_ENV }}
 
       - name: Sandbox - Postgres Flexible server Auto Stop
-        run: ./scripts/flexible-server/auto-start-stop.sh stop sandbox
+        run: ./scripts/flexible-server/auto-start-stop.sh stop sandbox '' primary
         env:
           DEV_ENV: ${{ env.DEV_ENV }}
 
       - name: ITHC - Postgres Flexible server Auto Stop
-        run: ./scripts/flexible-server/auto-start-stop.sh stop ithc
+        run: ./scripts/flexible-server/auto-start-stop.sh start ithc '' primary
         env:
           DEV_ENV: ${{ env.DEV_ENV }}
 
       - name: Untagged - Postgres Flexible server Auto Stop
-        run: ./scripts/flexible-server/auto-start-stop.sh stop untagged
+        run: ./scripts/flexible-server/auto-start-stop.sh stop untagged '' primary
+        env:
+          DEV_ENV: ${{ env.DEV_ENV }}
+
+      - name: Wait for 3 minutes
+        if: env.DEV_ENV == 'false'
+        run: sleep 180
+
+      # REPLICA
+      - name: Staging Replicas - Postgres Flexible server Auto Stop
+        run: ./scripts/flexible-server/auto-start-stop.sh stop staging '' replica
+        env:
+          DEV_ENV: ${{ env.DEV_ENV }}
+
+      - name: Test Replicas - Postgres Flexible server Auto Stop
+        run: ./scripts/flexible-server/auto-start-stop.sh stop testing '' replica
+        env:
+          DEV_ENV: ${{ env.DEV_ENV }}
+
+      - name: Demo Replicas - Postgres Flexible server Auto Stop
+        run: ./scripts/flexible-server/auto-start-stop.sh stop demo '' replica
+        env:
+          DEV_ENV: ${{ env.DEV_ENV }}
+
+      - name: Development Replicas - Postgres Flexible server Auto Stop
+        run: ./scripts/flexible-server/auto-start-stop.sh stop development '' replica
+        env:
+          DEV_ENV: ${{ env.DEV_ENV }}
+
+      - name: Sandbox Replicas - Postgres Flexible server Auto Stop
+        run: ./scripts/flexible-server/auto-start-stop.sh stop sandbox '' replica
+        env:
+          DEV_ENV: ${{ env.DEV_ENV }}
+
+      - name: ITHC Replicas - Postgres Flexible server Auto Stop
+        run: ./scripts/flexible-server/auto-start-stop.sh stop ithc '' replica
+        env:
+          DEV_ENV: ${{ env.DEV_ENV }}
+
+      - name: Untagged Replicas - Postgres Flexible server Auto Stop
+        run: ./scripts/flexible-server/auto-start-stop.sh stop untagged '' replica
         env:
           DEV_ENV: ${{ env.DEV_ENV }}
 

--- a/.github/workflows/flexibleserver-auto-start.yaml
+++ b/.github/workflows/flexibleserver-auto-start.yaml
@@ -2,7 +2,7 @@ name: flexible-server-auto-start
 on:
   workflow_dispatch:
   schedule:
-    - cron: '15 5 * * 1-5' # Every weekday at 6:15am BST
+    - cron: "15 5 * * 1-5" # Every weekday at 6:15am BST
 env:
   DEV_ENV: ${{ secrets.DEV_ENV }}
 permissions:
@@ -13,7 +13,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: 'Az CLI login'
+      - name: "Az CLI login"
         uses: azure/login@v2
         with:
           client-id: 2b6fa9d7-7dba-4600-a58a-5e25554997aa # DTS AKS Auto-Shutdown
@@ -55,6 +55,10 @@ jobs:
         run: ./scripts/flexible-server/auto-start-stop.sh start untagged '' replica
         env:
           DEV_ENV: ${{ env.DEV_ENV }}
+
+      - name: Wait for 3 minutes
+        if: env.DEV_ENV == 'false'
+        run: sleep 180
 
       # PRIMARY
       - name: Staging - Postgres Flexible server Auto Start


### PR DESCRIPTION
### Jira link

### Change description
- Splits flex auto stop into primary and replica DBs 
- Adds 3 minute wait between each type to prevent start/stop issues
- `Primary must be stopped before stopping read replicas. Replicas must be started before starting primary.`
<!--
Provide a description of what change you are proposing.
A short summary here and then you can add comments in your pull request explaining your change to others.
-->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is not always complete, so a successful pull request build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
