### PR TITLE
Disable Flexible Server start/shutdowns

### DIFF
--- a/.github/workflows/flexibleserver-auto-shutdown.yaml
+++ b/.github/workflows/flexibleserver-auto-shutdown.yaml
@@ -1,8 +1,8 @@
 name: flexible-server-auto-shutdown
 on:
   workflow_dispatch:
-  schedule:
-    - cron: "15 19,22 * * *" # Every day at 20:15 and 23:15 BST
+  #schedule:
+  #  - cron: "15 19,22 * * *" # Every day at 20:15 and 23:15 BST
 env:
   DEV_ENV: ${{ secrets.DEV_ENV }}
 permissions:

--- a/.github/workflows/flexibleserver-auto-start.yaml
+++ b/.github/workflows/flexibleserver-auto-start.yaml
@@ -1,8 +1,8 @@
 name: flexible-server-auto-start
 on:
   workflow_dispatch:
-  schedule:
-    - cron: "1 5 * * 1-5" # Every weekday at 6:01am BST // bucket 1
+  #schedule:
+  #  - cron: "1 5 * * 1-5" # Every weekday at 6:01am BST // bucket 1
 
 env:
   DEV_ENV: ${{ secrets.DEV_ENV }}


### PR DESCRIPTION
DTSO-33610

### Change description

We have been having regular issues getting the PostgreSQL servers to start up in the morning following a shutdown the night before. This ticket is to disable the PG FlexibleServer scheduled job until Microsoft put a fix in place. Microsoft have also  committed to bear the cost

### Testing done



### Security Vulnerability Assessment ###

<!-- Comment:
If Yes to the below question, please provide details below:
CVE ID(s): (List all suppressed or relevant CVE IDs)
Reason for Suppression/Ignoring: (e.g., Low risk in our specific context, Mitigating controls in place, False positive - with justification)
Mitigating Factors/Compensating Controls: Describe any measures taken to reduce the risk associated with the vulnerability
-->

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [ x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ x] commit messages are meaningful and follow good commit message guidelines
- [ x] README and other documentation has been updated / added (if needed)
- [x ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
